### PR TITLE
feature(SMTP): Make it possible to choose between TLS, StartTLS et insecure SMTP connection

### DIFF
--- a/doc/1/guides/overview/index.md
+++ b/doc/1/guides/overview/index.md
@@ -46,6 +46,12 @@ app.start()
 
     // Add a "common" SMTP account
     hermesMessengerPlugin.clients.smtp.addAccount('common', 'smtp.example.com', 587, 'dummyUser', 'dummyPass', 'amaret@kuzzle.io');
+
+    // Add a "starttls" SMTP account
+    hermesMessengerPlugin.clients.smtp.addAccount('starttls', 'smtp.example.com', 587, 'dummyUser', 'dummyPass', 'amaret@kuzzle.io', 'starttls');
+
+    // Add a "ssl" SMTP account
+    hermesMessengerPlugin.clients.smtp.addAccount('ssl', 'smtp.example.com', 465, 'dummyUser', 'dummyPass', 'amaret@kuzzle.io', 'ssl');
   })
   .catch(console.error);
 ```

--- a/lib/messenger-clients/SMTPClient.ts
+++ b/lib/messenger-clients/SMTPClient.ts
@@ -102,7 +102,7 @@ export class SMTPClient extends MessengerClient<SMTPAccount> {
     defaultSender: string,
     ssl: SMTPClientSSLMode = SMTPClientSSLMode.NONE
   ) {
-    super.addAccount(name, host, port, user, pass, defaultSender);
+    super.addAccount(name, host, port, user, pass, defaultSender, ssl);
   }
 
   protected _createAccount(
@@ -114,8 +114,6 @@ export class SMTPClient extends MessengerClient<SMTPAccount> {
     defaultSender: string,
     ssl: SMTPClientSSLMode = SMTPClientSSLMode.NONE
   ): SMTPAccount {
-
-
     const transporter = createTransport({
       auth: {
         pass,
@@ -124,7 +122,7 @@ export class SMTPClient extends MessengerClient<SMTPAccount> {
       host,
       port,
       secure: ssl === SMTPClientSSLMode.TLS,
-      requiredTls: ssl === SMTPClientSSLMode.STARTTLS,
+      requireTLS: ssl === SMTPClientSSLMode.STARTTLS,
       ignoreTLS: ssl === SMTPClientSSLMode.NONE,
     });
 

--- a/lib/messenger-clients/SMTPClient.ts
+++ b/lib/messenger-clients/SMTPClient.ts
@@ -16,6 +16,21 @@ export interface SMTPAccount
   };
 }
 
+export enum SMTPClientSSLMode {
+  /**
+   * Do not use SSL
+   */
+  NONE = "none",
+  /**
+   * Use StartTLS
+   */
+  STARTTLS = "starttls",
+  /**
+   * Use TLS on dedicated port
+   */
+  TLS = "tls",
+}
+
 export class SMTPClient extends MessengerClient<SMTPAccount> {
   constructor() {
     super("smtp");
@@ -78,13 +93,14 @@ export class SMTPClient extends MessengerClient<SMTPAccount> {
    * @param pass SMTP server password
    * @param defaultSender Default sender email address
    */
-  addAccount(
+  override addAccount(
     name: string,
     host: string,
     port: number,
     user: string,
     pass: string,
-    defaultSender: string
+    defaultSender: string,
+    ssl: SMTPClientSSLMode = SMTPClientSSLMode.NONE
   ) {
     super.addAccount(name, host, port, user, pass, defaultSender);
   }
@@ -95,8 +111,11 @@ export class SMTPClient extends MessengerClient<SMTPAccount> {
     port: number,
     user: string,
     pass: string,
-    defaultSender: string
+    defaultSender: string,
+    ssl: SMTPClientSSLMode = SMTPClientSSLMode.NONE
   ): SMTPAccount {
+
+
     const transporter = createTransport({
       auth: {
         pass,
@@ -104,7 +123,9 @@ export class SMTPClient extends MessengerClient<SMTPAccount> {
       },
       host,
       port,
-      secure: port === 465,
+      secure: ssl === SMTPClientSSLMode.TLS,
+      requiredTls: ssl === SMTPClientSSLMode.STARTTLS,
+      ignoreTLS: ssl === SMTPClientSSLMode.NONE,
     });
 
     return {

--- a/tests/application/app.ts
+++ b/tests/application/app.ts
@@ -1,6 +1,6 @@
 import { Backend, KuzzleRequest } from "kuzzle";
 
-import { HermesMessengerPlugin } from "../../index";
+import { HermesMessengerPlugin, SMTPClientSSLMode } from "../../index";
 
 const app = new Backend("kuzzle");
 
@@ -31,7 +31,28 @@ hermesMessengerPlugin.clients.smtp.addAccount(
   587,
   "dummyUser",
   "dummyPass",
-  "amaret@kuzzle.io"
+  "amaret@kuzzle.io",
+  SMTPClientSSLMode.NONE
+);
+
+hermesMessengerPlugin.clients.smtp.addAccount(
+  "starttls",
+  "smtp.example.com",
+  587,
+  "dummyUser",
+  "dummyPass",
+  "amaret@kuzzle.io",
+  SMTPClientSSLMode.STARTTLS
+);
+
+hermesMessengerPlugin.clients.smtp.addAccount(
+  "tls",
+  "smtp.example.com",
+  465,
+  "dummyUser",
+  "dummyPass",
+  "amaret@kuzzle.io",
+  SMTPClientSSLMode.TLS
 );
 
 

--- a/tests/application/app.ts
+++ b/tests/application/app.ts
@@ -25,6 +25,7 @@ hermesMessengerPlugin.clients.sendgrid.addAccount(
   "SG.apiKey",
   "amaret@kuzzle.io"
 );
+
 hermesMessengerPlugin.clients.smtp.addAccount(
   "common",
   "smtp.example.com",

--- a/tests/scenarios/sendgrid.test.ts
+++ b/tests/scenarios/sendgrid.test.ts
@@ -179,15 +179,18 @@ describe("Sendgrid", () => {
       action: "listAccounts",
     });
 
-    expect(response.result).toMatchObject({
-      accounts: [
-        { name: "common", options: { defaultSender: "amaret@kuzzle.io" } },
-        { name: "ilayda", options: { defaultSender: "ilayda@gmail.com" } },
-        {
-          name: "water-fairy",
-          options: { defaultSender: "water-fairy@gmail.com" },
-        },
-      ],
+    expect(response.result.accounts).toHaveLength(3);
+    expect(response.result.accounts).toContainEqual({
+      name: "common",
+      options: { defaultSender: "amaret@kuzzle.io" },
+    });
+    expect(response.result.accounts).toContainEqual({
+      name: "ilayda",
+      options: { defaultSender: "ilayda@gmail.com" },
+    });
+    expect(response.result.accounts).toContainEqual({
+      name: "water-fairy",
+      options: { defaultSender: "water-fairy@gmail.com" },
     });
 
     await node1.query({
@@ -201,11 +204,14 @@ describe("Sendgrid", () => {
       action: "listAccounts",
     });
 
-    expect(response.result).toMatchObject({
-      accounts: [
-        { name: "common", options: { defaultSender: "amaret@kuzzle.io" } },
-        { name: "ilayda", options: { defaultSender: "ilayda@gmail.com" } },
-      ],
+    expect(response.result.accounts).toHaveLength(2);
+    expect(response.result.accounts).toContainEqual({
+      name: "common",
+      options: { defaultSender: "amaret@kuzzle.io" },
+    });
+    expect(response.result.accounts).toContainEqual({
+      name: "ilayda",
+      options: { defaultSender: "ilayda@gmail.com" },
     });
 
     response = await node1.query({
@@ -213,11 +219,14 @@ describe("Sendgrid", () => {
       action: "listAccounts",
     });
 
-    expect(response.result).toMatchObject({
-      accounts: [
-        { name: "common", options: { defaultSender: "amaret@kuzzle.io" } },
-        { name: "ilayda", options: { defaultSender: "ilayda@gmail.com" } },
-      ],
+    expect(response.result.accounts).toHaveLength(2);
+    expect(response.result.accounts).toContainEqual({
+      name: "common",
+      options: { defaultSender: "amaret@kuzzle.io" },
+    });
+    expect(response.result.accounts).toContainEqual({
+      name: "ilayda",
+      options: { defaultSender: "ilayda@gmail.com" },
     });
 
     response = await node2.query({
@@ -225,11 +234,14 @@ describe("Sendgrid", () => {
       action: "listAccounts",
     });
 
-    expect(response.result).toMatchObject({
-      accounts: [
-        { name: "common", options: { defaultSender: "amaret@kuzzle.io" } },
-        { name: "ilayda", options: { defaultSender: "ilayda@gmail.com" } },
-      ],
+    expect(response.result.accounts).toHaveLength(2);
+    expect(response.result.accounts).toContainEqual({
+      name: "common",
+      options: { defaultSender: "amaret@kuzzle.io" },
+    });
+    expect(response.result.accounts).toContainEqual({
+      name: "ilayda",
+      options: { defaultSender: "ilayda@gmail.com" },
     });
 
     response = await node3.query({
@@ -237,11 +249,14 @@ describe("Sendgrid", () => {
       action: "listAccounts",
     });
 
-    expect(response.result).toMatchObject({
-      accounts: [
-        { name: "common", options: { defaultSender: "amaret@kuzzle.io" } },
-        { name: "ilayda", options: { defaultSender: "ilayda@gmail.com" } },
-      ],
+    expect(response.result.accounts).toHaveLength(2);
+    expect(response.result.accounts).toContainEqual({
+      name: "common",
+      options: { defaultSender: "amaret@kuzzle.io" },
+    });
+    expect(response.result.accounts).toContainEqual({
+      name: "ilayda",
+      options: { defaultSender: "ilayda@gmail.com" },
     });
   });
 });

--- a/tests/scenarios/smtp.test.ts
+++ b/tests/scenarios/smtp.test.ts
@@ -226,9 +226,13 @@ describe("SMTP", () => {
       action: "listAccounts",
     });
 
+    console.log(response.result);
+
     expect(response.result).toMatchObject({
       accounts: [
         { name: "common", options: { defaultSender: "amaret@kuzzle.io" } },
+        { name: "starttls", options: { defaultSender: "amaret@kuzzle.io" } },
+        { name: "tls", options: { defaultSender: "amaret@kuzzle.io" } },
         { name: "ilayda", options: { defaultSender: "ilayda@gmail.com" } },
         {
           name: "water-fairy",

--- a/tests/scenarios/smtp.test.ts
+++ b/tests/scenarios/smtp.test.ts
@@ -226,17 +226,26 @@ describe("SMTP", () => {
       action: "listAccounts",
     });
 
-    expect(response.result).toMatchObject({
-      accounts: [
-        { name: "common", options: { defaultSender: "amaret@kuzzle.io" } },
-        { name: "starttls", options: { defaultSender: "amaret@kuzzle.io" } },
-        { name: "tls", options: { defaultSender: "amaret@kuzzle.io" } },
-        { name: "ilayda", options: { defaultSender: "ilayda@gmail.com" } },
-        {
-          name: "water-fairy",
-          options: { defaultSender: "water-fairy@gmail.com" },
-        },
-      ],
+    expect(response.result.accounts).toHaveLength(5);
+    expect(response.result.accounts).toContainEqual({
+      name: "common",
+      options: { defaultSender: "amaret@kuzzle.io" },
+    });
+    expect(response.result.accounts).toContainEqual({
+      name: "ilayda",
+      options: { defaultSender: "ilayda@gmail.com" },
+    });
+    expect(response.result.accounts).toContainEqual({
+      name: "water-fairy",
+      options: { defaultSender: "water-fairy@gmail.com" },
+    });
+    expect(response.result.accounts).toContainEqual({
+      name: "starttls",
+      options: { defaultSender: "amaret@kuzzle.io" },
+    });
+    expect(response.result.accounts).toContainEqual({
+      name: "tls",
+      options: { defaultSender: "amaret@kuzzle.io" },
     });
 
     await node1.query({
@@ -250,11 +259,22 @@ describe("SMTP", () => {
       action: "listAccounts",
     });
 
-    expect(response.result).toMatchObject({
-      accounts: [
-        { name: "common", options: { defaultSender: "amaret@kuzzle.io" } },
-        { name: "ilayda", options: { defaultSender: "ilayda@gmail.com" } },
-      ],
+    expect(response.result.accounts).toHaveLength(4);
+    expect(response.result.accounts).toContainEqual({
+      name: "common",
+      options: { defaultSender: "amaret@kuzzle.io" },
+    });
+    expect(response.result.accounts).toContainEqual({
+      name: "ilayda",
+      options: { defaultSender: "ilayda@gmail.com" },
+    });
+    expect(response.result.accounts).toContainEqual({
+      name: "starttls",
+      options: { defaultSender: "amaret@kuzzle.io" },
+    });
+    expect(response.result.accounts).toContainEqual({
+      name: "tls",
+      options: { defaultSender: "amaret@kuzzle.io" },
     });
 
     response = await node1.query({
@@ -262,11 +282,22 @@ describe("SMTP", () => {
       action: "listAccounts",
     });
 
-    expect(response.result).toMatchObject({
-      accounts: [
-        { name: "common", options: { defaultSender: "amaret@kuzzle.io" } },
-        { name: "ilayda", options: { defaultSender: "ilayda@gmail.com" } },
-      ],
+    expect(response.result.accounts).toHaveLength(4);
+    expect(response.result.accounts).toContainEqual({
+      name: "common",
+      options: { defaultSender: "amaret@kuzzle.io" },
+    });
+    expect(response.result.accounts).toContainEqual({
+      name: "ilayda",
+      options: { defaultSender: "ilayda@gmail.com" },
+    });
+    expect(response.result.accounts).toContainEqual({
+      name: "starttls",
+      options: { defaultSender: "amaret@kuzzle.io" },
+    });
+    expect(response.result.accounts).toContainEqual({
+      name: "tls",
+      options: { defaultSender: "amaret@kuzzle.io" },
     });
 
     response = await node2.query({
@@ -274,11 +305,22 @@ describe("SMTP", () => {
       action: "listAccounts",
     });
 
-    expect(response.result).toMatchObject({
-      accounts: [
-        { name: "common", options: { defaultSender: "amaret@kuzzle.io" } },
-        { name: "ilayda", options: { defaultSender: "ilayda@gmail.com" } },
-      ],
+    expect(response.result.accounts).toHaveLength(4);
+    expect(response.result.accounts).toContainEqual({
+      name: "common",
+      options: { defaultSender: "amaret@kuzzle.io" },
+    });
+    expect(response.result.accounts).toContainEqual({
+      name: "ilayda",
+      options: { defaultSender: "ilayda@gmail.com" },
+    });
+    expect(response.result.accounts).toContainEqual({
+      name: "starttls",
+      options: { defaultSender: "amaret@kuzzle.io" },
+    });
+    expect(response.result.accounts).toContainEqual({
+      name: "tls",
+      options: { defaultSender: "amaret@kuzzle.io" },
     });
 
     response = await node3.query({
@@ -286,11 +328,22 @@ describe("SMTP", () => {
       action: "listAccounts",
     });
 
-    expect(response.result).toMatchObject({
-      accounts: [
-        { name: "common", options: { defaultSender: "amaret@kuzzle.io" } },
-        { name: "ilayda", options: { defaultSender: "ilayda@gmail.com" } },
-      ],
+    expect(response.result.accounts).toHaveLength(4);
+    expect(response.result.accounts).toContainEqual({
+      name: "common",
+      options: { defaultSender: "amaret@kuzzle.io" },
+    });
+    expect(response.result.accounts).toContainEqual({
+      name: "ilayda",
+      options: { defaultSender: "ilayda@gmail.com" },
+    });
+    expect(response.result.accounts).toContainEqual({
+      name: "starttls",
+      options: { defaultSender: "amaret@kuzzle.io" },
+    });
+    expect(response.result.accounts).toContainEqual({
+      name: "tls",
+      options: { defaultSender: "amaret@kuzzle.io" },
     });
   });
 });

--- a/tests/scenarios/smtp.test.ts
+++ b/tests/scenarios/smtp.test.ts
@@ -226,8 +226,6 @@ describe("SMTP", () => {
       action: "listAccounts",
     });
 
-    console.log(response.result);
-
     expect(response.result).toMatchObject({
       accounts: [
         { name: "common", options: { defaultSender: "amaret@kuzzle.io" } },

--- a/tests/scenarios/twilio.test.ts
+++ b/tests/scenarios/twilio.test.ts
@@ -124,12 +124,18 @@ describe("Twilio", () => {
       action: "listAccounts",
     });
 
-    expect(response.result).toMatchObject({
-      accounts: [
-        { name: "common", options: { defaultSender: "+33629951621" } },
-        { name: "ilayda", options: { defaultSender: "+9053365366473" } },
-        { name: "water-fairy", options: { defaultSender: "+9053365366472" } },
-      ],
+    expect(response.result.accounts).toHaveLength(3);
+    expect(response.result.accounts).toContainEqual({
+      name: "common",
+      options: { defaultSender: "+33629951621" },
+    });
+    expect(response.result.accounts).toContainEqual({
+      name: "ilayda",
+      options: { defaultSender: "+9053365366473" },
+    });
+    expect(response.result.accounts).toContainEqual({
+      name: "water-fairy",
+      options: { defaultSender: "+9053365366472" },
     });
 
     await node1.query({
@@ -143,11 +149,14 @@ describe("Twilio", () => {
       action: "listAccounts",
     });
 
-    expect(response.result).toMatchObject({
-      accounts: [
-        { name: "common", options: { defaultSender: "+33629951621" } },
-        { name: "ilayda", options: { defaultSender: "+9053365366473" } },
-      ],
+    expect(response.result.accounts).toHaveLength(2);
+    expect(response.result.accounts).toContainEqual({
+      name: "common",
+      options: { defaultSender: "+33629951621" },
+    });
+    expect(response.result.accounts).toContainEqual({
+      name: "ilayda",
+      options: { defaultSender: "+9053365366473" },
     });
 
     response = await node2.query({
@@ -155,11 +164,14 @@ describe("Twilio", () => {
       action: "listAccounts",
     });
 
-    expect(response.result).toMatchObject({
-      accounts: [
-        { name: "common", options: { defaultSender: "+33629951621" } },
-        { name: "ilayda", options: { defaultSender: "+9053365366473" } },
-      ],
+    expect(response.result.accounts).toHaveLength(2);
+    expect(response.result.accounts).toContainEqual({
+      name: "common",
+      options: { defaultSender: "+33629951621" },
+    });
+    expect(response.result.accounts).toContainEqual({
+      name: "ilayda",
+      options: { defaultSender: "+9053365366473" },
     });
 
     response = await node3.query({
@@ -167,11 +179,14 @@ describe("Twilio", () => {
       action: "listAccounts",
     });
 
-    expect(response.result).toMatchObject({
-      accounts: [
-        { name: "common", options: { defaultSender: "+33629951621" } },
-        { name: "ilayda", options: { defaultSender: "+9053365366473" } },
-      ],
+    expect(response.result.accounts).toHaveLength(2);
+    expect(response.result.accounts).toContainEqual({
+      name: "common",
+      options: { defaultSender: "+33629951621" },
+    });
+    expect(response.result.accounts).toContainEqual({
+      name: "ilayda",
+      options: { defaultSender: "+9053365366473" },
     });
   });
 });


### PR DESCRIPTION
## What does this PR do ?

Add the feature allowing developer to choose between insecure, TLS or StartTLS connection where instantiating a new SMTP client from the Hermes Plugin

```
hermesMessengerPlugin.clients.smtp.addAccount(
  "common",
  "smtp.example.com",
  587,
  "dummyUser",
  "dummyPass",
  "amaret@kuzzle.io",
  SMTPClientSSLMode.NONE
);

hermesMessengerPlugin.clients.smtp.addAccount(
  "starttls",
  "smtp.example.com",
  587,
  "dummyUser",
  "dummyPass",
  "amaret@kuzzle.io",
  SMTPClientSSLMode.STARTTLS
);

hermesMessengerPlugin.clients.smtp.addAccount(
  "tls",
  "smtp.example.com",
  465,
  "dummyUser",
  "dummyPass",
  "amaret@kuzzle.io",
  SMTPClientSSLMode.TLS
);
```
