### PR TITLE
Fix/improve smtp error return

### DIFF
--- a/.github/actions/functional-test/action.yml
+++ b/.github/actions/functional-test/action.yml
@@ -7,6 +7,6 @@ runs:
       shell: bash
       run: |
         npm run docker npm ci
-        docker-compose up -d
+        docker compose up -d
         bash tests/wait-kuzzle.sh
         npm run test

--- a/doc/1/controllers/sendgrid/sendEmail/index.md
+++ b/doc/1/controllers/sendgrid/sendEmail/index.md
@@ -32,6 +32,15 @@ Method: POST
     "subject": "<email subject>",
     "html": "<email body>",
     "from": "<sender email>", // optional
+    "attachments": [ // optional
+      {
+        "content": "<base64 encoded attachment content>",
+        "contentType": "<attachment content type>",
+        "filename": "<attachment file name>",
+        "contentDisposition": "attachment" | "inline",
+        "cid": "<content ID if inline attachment>" // optional
+      }
+    ]
   }
 }
 ```

--- a/doc/1/controllers/sendgrid/sendTemplatedEmail/index.md
+++ b/doc/1/controllers/sendgrid/sendTemplatedEmail/index.md
@@ -34,6 +34,15 @@ Method: POST
     },
     "templateId": "<template ID>",
     "from": "<sender email>", // optional
+    "attachments": [ // optional
+      {
+        "content": "<base64 encoded attachment content>",
+        "contentType": "<attachment content type>",
+        "filename": "<attachment file name>",
+        "contentDisposition": "attachment" | "inline",
+        "cid": "<content ID if inline attachment>" // optional
+      }
+    ]
   }
 }
 ```

--- a/lib/HermesMessengerPlugin.ts
+++ b/lib/HermesMessengerPlugin.ts
@@ -132,9 +132,12 @@ export class HermesMessengerPlugin extends Plugin {
               properties: {
                 content: { type: "keyword" },
                 contentType: { type: "keyword" },
+                type: { type: "keyword" },
                 filename: { type: "keyword" },
                 contentDisposition: { type: "keyword" },
+                disposition: { type: "keyword" },
                 cid: { type: "keyword" },
+                content_id: { type: "keyword" },
               },
             },
 

--- a/lib/controllers/SendgridController.ts
+++ b/lib/controllers/SendgridController.ts
@@ -5,15 +5,13 @@ import {
   PluginContext,
   ControllerDefinition,
 } from "kuzzle";
-
 import { SendgridClient } from "../messenger-clients";
+import { Attachment, SendgridAttachment } from "lib/types";
 
 export class SendgridController {
   private context: PluginContext;
   private config: JSONObject;
-
   private sendgridClient: SendgridClient;
-
   definition: ControllerDefinition;
 
   get sdk(): EmbeddedSDK {
@@ -64,7 +62,20 @@ export class SendgridController {
 
     const from = fromEmail.length === 0 ? null : fromEmail;
 
-    await this.sendgridClient.sendEmail(account, to, subject, html, { from });
+    const attachments = request.getBodyArray("attachments", []).map(
+      (attachment: Attachment): SendgridAttachment => ({
+        content: attachment.content,
+        filename: attachment.filename,
+        type: attachment.contentType,
+        disposition: attachment.contentDisposition,
+        content_id: attachment.cid,
+      })
+    );
+
+    await this.sendgridClient.sendEmail(account, to, subject, html, {
+      from,
+      attachments,
+    });
   }
 
   async sendTemplatedEmail(request: KuzzleRequest) {
@@ -76,12 +87,22 @@ export class SendgridController {
 
     const from = fromEmail.length === 0 ? null : fromEmail;
 
+    const attachments = request.getBodyArray("attachments", []).map(
+      (attachment: Attachment): SendgridAttachment => ({
+        content: attachment.content,
+        filename: attachment.filename,
+        type: attachment.contentType,
+        disposition: attachment.contentDisposition,
+        content_id: attachment.cid,
+      })
+    );
+
     await this.sendgridClient.sendTemplatedEmail(
       account,
       to,
       templateId,
       templateData,
-      { from }
+      { from, attachments }
     );
   }
 

--- a/lib/messenger-clients/SMTPClient.ts
+++ b/lib/messenger-clients/SMTPClient.ts
@@ -58,13 +58,7 @@ export class SMTPClient extends MessengerClient<SMTPAccount> {
     try {
       await this.sendMessage(account, email);
     } catch (error) {
-      if (error.response) {
-        throw new ExternalServiceError(
-          "SMTP " + JSON.stringify(error.response.body)
-        );
-      }
-
-      throw new ExternalServiceError(error);
+      throw new ExternalServiceError(`SMTP: ${JSON.stringify(error)}`);
     }
   }
 

--- a/lib/messenger-clients/SendgridClient.ts
+++ b/lib/messenger-clients/SendgridClient.ts
@@ -2,6 +2,7 @@ import { MailService } from "@sendgrid/mail";
 import { ExternalServiceError, JSONObject } from "kuzzle";
 
 import { BaseAccount, MessengerClient } from "./MessengerClient";
+import { SendgridAttachment } from "lib/types";
 
 export interface SendgridAccount extends BaseAccount<MailService> {
   options: {
@@ -25,24 +26,34 @@ export class SendgridClient extends MessengerClient<SendgridAccount> {
    * @param subject Email subject
    * @param html Email content
    * @param options.from Sender email
+   * @param options.attachments Attachments to be included in the email
    */
   async sendEmail(
     accountName: string,
     to: string[],
     subject: string,
     html: string,
-    { from }: { from?: string } = {}
+    {
+      from,
+      attachments,
+    }: { from?: string; attachments?: SendgridAttachment[] } = {}
   ) {
     const account = this.getAccount(accountName);
 
     const fromEmail = from || account.options.defaultSender;
 
-    const email = { from: fromEmail, to, subject, html };
+    const email = {
+      from: fromEmail,
+      to,
+      subject,
+      html,
+      attachments,
+    };
 
     this.context.log.debug(
       `EMAIL (${accountName}): FROM ${fromEmail} TO ${to.join(
         ", "
-      )} SUBJECT ${subject}`
+      )} SUBJECT ${subject} ATTACHMENTS ${attachments?.length || 0}`
     );
 
     try {
@@ -59,20 +70,24 @@ export class SendgridClient extends MessengerClient<SendgridAccount> {
   }
 
   /**
-   * Sends a tempated email using one of the registered accounts.
+   * Sends a templated email using one of the registered accounts.
    *
    * @param accountName Account name
-   * @param from Sender email
    * @param to Recipient email(s)
    * @param templateId Template ID
    * @param templateData Template placeholders values
+   * @param options.from Sender email
+   * @param options.attachments Attachments to be included in the email
    */
   async sendTemplatedEmail(
     accountName: string,
     to: string[],
     templateId: string,
     templateData: JSONObject,
-    { from }: { from?: string } = {}
+    {
+      from,
+      attachments,
+    }: { from?: string; attachments?: SendgridAttachment[] } = {}
   ) {
     const account = this.getAccount(accountName);
 
@@ -83,12 +98,13 @@ export class SendgridClient extends MessengerClient<SendgridAccount> {
       to,
       templateId,
       dynamic_template_data: templateData,
+      attachments,
     };
 
     this.context.log.debug(
       `EMAIL (${accountName}): FROM ${fromEmail} TO ${to.join(
         ", "
-      )} TEMPLATE ${templateId}`
+      )} TEMPLATE ${templateId} ATTACHMENTS ${attachments?.length || 0}`
     );
 
     try {
@@ -127,7 +143,7 @@ export class SendgridClient extends MessengerClient<SendgridAccount> {
     };
   }
 
-  private async sendMessage(account: SendgridAccount, email: any) {
+  private async sendMessage(account: SendgridAccount, email) {
     if (await this.mockedAccount(account.name)) {
       await this.sdk.document.createOrReplace(
         this.config.adminIndex,

--- a/lib/types/Attachment.ts
+++ b/lib/types/Attachment.ts
@@ -5,3 +5,11 @@ export interface Attachment {
   contentDisposition: "attachment" | "inline";
   cid?: string;
 }
+
+export interface SendgridAttachment {
+  content: string;
+  type: string;
+  filename: string;
+  disposition: "attachment" | "inline";
+  content_id?: string;
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "docker": "docker-compose run kuzzle_node_1 ",
+    "docker": "docker compose run kuzzle_node_1 ",
     "dev": "NODE_ENV=development ergol tests/application/app.ts -c ergol.config.json",
     "prod": "node ./dist/tests/application/app.js",
     "test": "jest --runInBand",

--- a/tests/scenarios/sendgrid.test.ts
+++ b/tests/scenarios/sendgrid.test.ts
@@ -127,6 +127,15 @@ describe("Sendgrid", () => {
         from: "support@kuzzle.io",
         to: ["jobs@kuzzle.io"],
         templateData: { foo: "bar" },
+        attachments: [
+          {
+            content: "base64filecontent",
+            filename: "dummyfile.pdf",
+            contentType: "pdf",
+            contentDisposition: "inline",
+            content_id: "dummyCid",
+          },
+        ],
       },
     });
 

--- a/tests/wait-kuzzle.sh
+++ b/tests/wait-kuzzle.sh
@@ -14,7 +14,7 @@ do
     ((tries=tries+1))
 
     if [ $tries -eq $max_tries ]; then
-        docker-compose logs
+        docker compose logs
         curl http://localhost:7512?pretty
         echo "Cannot connect to Kuzzle after $tries tries. Aborting."
         exit 1


### PR DESCRIPTION
Will avoid to have undefined errors : 
example: 
`
{"level":"error","message":"2024-09-24 10-45-08 [LOG:ERROR] [knode-responsive-gaia-74820] [5a9f83b3-2ad1-4e0d-bdfd-4da0977f8fe3] [workflows] [tenant-chillnet_tenant-chill] Cannot execute workflow \"workflow--scheduled-report-1723483109074-0\": ExternalServiceError: SMTP undefined\n    at new ExternalServiceError (/var/app/node_modules/kuzzle/lib/kerror/errors/externalServiceError.js:27:9)\n    at SMTPClient.sendEmail (/var/app/node_modules/kuzzle-plugin-hermes-messenger/dist/lib/messenger-clients/SMTPClient.js:36:23)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async SMTPController.sendEmail (/var/app/node_modules/kuzzle-plugin-hermes-messenger/dist/lib/controllers/SMTPController.js:42:9)\n    at async Funnel.executePluginRequest (/var/app/node_modules/kuzzle/lib/api/funnel.js:759:14)\n    at async FunnelProtocol.query (/var/app/node_modules/kuzzle/lib/core/shared/sdk/funnelProtocol.js:95:24)\n    at async ScheduledDashboardExportTask.sendDashboardExport (/var/app/node_modules/@kuzzleio/iot-platform-backend/dist/modules/dashboard/tasks/ScheduledDashboardExportTask.js:62:9)\n    at async ScheduledDashboardExportTask.run (/var/app/node_modules/@kuzzleio/iot-platform-backend/dist/modules/dashboard/tasks/ScheduledDashboardExportTask.js:97:9)\n    at async TaskExecutor.execute (/var/app/node_modules/@kuzzleio/plugin-workflows/dist/lib/actions/task/TaskExecutor.js:27:13)\n    at async ActionsExecutor.execute (/var/app/node_modules/@kuzzleio/plugin-workflows/dist/lib/actions/ActionsExecutor.js:38:25)\n    at async SchedulerTrigger.tryExecuteOnNode (/var/app/node_modules/@kuzzleio/plugin-workflows/dist/lib/triggers/scheduler/SchedulerTrigger.js:206:17)\n    at async Promise.all (index 0)\n    at async Timeout._onTimeout (/var/app/node_modules/@kuzzleio/plugin-workflows/dist/lib/triggers/scheduler/SchedulerTrigger.js:167:17)"}
`