### PR TITLE
fix: add logging to sendEmail try catch, throw all response content

### DIFF
--- a/lib/messenger-clients/SMTPClient.ts
+++ b/lib/messenger-clients/SMTPClient.ts
@@ -58,7 +58,14 @@ export class SMTPClient extends MessengerClient<SMTPAccount> {
     try {
       await this.sendMessage(account, email);
     } catch (error) {
-      if (error.response) {
+      this.context.log.warn(
+        `An error occured while trying to send a message: ${JSON.stringify(
+          error,
+          null,
+          2
+        )}`
+      );
+      if (error.response?.body) {
         throw new ExternalServiceError(
           "SMTP " + JSON.stringify(error.response.body)
         );


### PR DESCRIPTION
- add logs to correctly trace SMTP errors. 