### PR TITLE
feat(providers): mutualize recipientType and validation

### DIFF
--- a/doc/2/guides/custom-provider/index.md
+++ b/doc/2/guides/custom-provider/index.md
@@ -10,6 +10,8 @@ order: 200
 
 Hermes Messenger is extensible. Any messaging service can be integrated by extending the `BaseProvider<T>` abstract class exported from the package.
 
+Recipient validation is **mutualized** across providers: a provider does not define its own recipient schema. Instead it declares which `recipientType`s it accepts (e.g. `email`, `phoneNumber`, or a custom one you register), and validation is delegated to the [`RecipientTypeRegistry`](#registering-a-custom-recipient-type). This lets several providers share the same recipient shape (e.g. two email providers both accepting `email`).
+
 ---
 
 ## 1. Define the account interface
@@ -17,10 +19,10 @@ Hermes Messenger is extensible. Any messaging service can be integrated by exten
 The account interface describes what is stored in memory for each registered account. The `options` field is the only part exposed by `listAccounts` — never put credentials there.
 
 ```typescript
-import { BaseAccount } from 'kuzzle-plugin-hermes-messenger';
+import { BaseAccount } from "kuzzle-plugin-hermes-messenger";
 
 interface MyAccount extends BaseAccount<MyClient> {
-  provider: MyClient;     // the live SDK client
+  provider: MyClient; // the live SDK client
   options: {
     defaultSender: string; // safe to expose
   };
@@ -32,47 +34,65 @@ interface MyAccount extends BaseAccount<MyClient> {
 ## 2. Implement the provider class
 
 ```typescript
-import { BaseProvider, ProviderType } from 'kuzzle-plugin-hermes-messenger';
-import { JSONSchema7 } from 'json-schema';
+import {
+  BaseProvider,
+  ProviderType,
+  RecipientTypeRegistry,
+} from "kuzzle-plugin-hermes-messenger";
+import { JSONSchema7 } from "json-schema";
 
 export class MyProvider extends BaseProvider<MyAccount> {
-  constructor() {
+  // Optional overrides — defaults are `false` / `"short"`.
+  override supportAttachment = false;
+  override messageType: "short" | "long" = "short";
+
+  constructor(recipientTypeRegistry: RecipientTypeRegistry) {
     // paramsJsonSchema: shape of the credentials passed to addAccount
     const paramsJsonSchema: JSONSchema7 = {
-      type: 'object',
+      type: "object",
       properties: {
-        apiKey:        { type: 'string', minLength: 1 },
-        defaultSender: { type: 'string', minLength: 1 },
+        apiKey: { type: "string", minLength: 1 },
+        defaultSender: { type: "string", minLength: 1 },
       },
-      required: ['apiKey', 'defaultSender'],
-    };
-
-    // recipientsJsonSchema: shape of each element in the recipients array
-    const recipientsJsonSchema: JSONSchema7 = {
-      type: 'object',
-      properties: {
-        to: { type: 'string' },
-      },
-      required: ['to'],
+      required: ["apiKey", "defaultSender"],
     };
 
     // contentJsonSchema: shape of the content object
     const contentJsonSchema: JSONSchema7 = {
-      type: 'object',
+      type: "object",
       properties: {
-        text: { type: 'string' },
+        text: { type: "string" },
       },
-      required: ['text'],
+      required: ["text"],
     };
 
-    super('my-provider', ProviderType.SMS, paramsJsonSchema, recipientsJsonSchema, contentJsonSchema);
+    // sendParamsJsonSchema: shape of the optional `params` object passed to send()
+    const sendParamsJsonSchema: JSONSchema7 = {
+      type: "object",
+      properties: {
+        from: { type: "string" },
+      },
+    };
+
+    super(
+      "my-provider",
+      ProviderType.SMS,
+      ["phoneNumber"], // acceptedRecipientTypes — must already be registered, see below
+      paramsJsonSchema,
+      contentJsonSchema,
+      sendParamsJsonSchema,
+      recipientTypeRegistry,
+    );
   }
 
   /**
    * Called by addAccount() — create and store a live SDK client.
-   * The order of positional args must match Object.values() of the params body.
+   * `params` is the raw object validated against paramsJsonSchema.
    */
-  protected _createAccount(name: string, apiKey: string, defaultSender: string): MyAccount {
+  protected _createAccount(
+    name: string,
+    { apiKey, defaultSender }: { apiKey: string; defaultSender: string },
+  ): MyAccount {
     return {
       name,
       provider: new MyClient(apiKey),
@@ -81,22 +101,23 @@ export class MyProvider extends BaseProvider<MyAccount> {
   }
 
   /**
-   * Send a message. The params object is passed directly from the request body's
-   * "params" field by the controller.
+   * Send a message. `recipients` are entries matching one of acceptedRecipientTypes'
+   * jsonSchema (here: `phoneNumber`'s `{ to: string }`). `params` is passed directly
+   * from the request body's "params" field by the controller.
    */
   async send(
     accountName: string,
     recipients: Array<{ to: string }>,
     content: { text: string },
-    params: { from?: string } = {}
+    params: { from?: string } = {},
   ): Promise<void> {
     const account = this.getAccount(accountName);
     const sender = params.from ?? account.options.defaultSender;
 
     await Promise.all(
       recipients.map((r) =>
-        account.provider.send({ to: r.to, from: sender, text: content.text })
-      )
+        account.provider.send({ to: r.to, from: sender, text: content.text }),
+      ),
     );
   }
 }
@@ -106,14 +127,21 @@ export class MyProvider extends BaseProvider<MyAccount> {
 
 ## 3. Register the provider
 
-Providers must be registered before `app.start()` is called:
+`acceptedRecipientTypes` must already be known to the registry when the provider is registered — `registerProvider()` throws a `BadRequestError` otherwise. Built-in types (`email`, `phoneNumber`) are registered by the plugin itself; register any custom type first (see below).
 
 ```typescript
-import { HermesMessengerPlugin } from 'kuzzle-plugin-hermes-messenger';
-import { MyProvider } from './providers/MyProvider';
+import { HermesMessengerPlugin } from "kuzzle-plugin-hermes-messenger";
+import { MyProvider } from "./providers/MyProvider";
 
 const plugin = new HermesMessengerPlugin();
-plugin.registerProvider('my-provider', new MyProvider());
+
+// only needed if 'my-provider' references a recipientType that isn't built in
+// plugin.registerRecipientType(myCustomRecipientType);
+
+plugin.registerProvider(
+  "my-provider",
+  new MyProvider(plugin.recipientTypeRegistry),
+);
 app.plugin.use(plugin);
 ```
 
@@ -124,11 +152,10 @@ app.plugin.use(plugin);
 ```typescript
 await app.start();
 
-plugin.getProvider('my-provider').addAccount(
-  'default',        // account name
-  'my_api_key',     // apiKey
-  'sender@example.com' // defaultSender
-);
+plugin.getProvider("my-provider").addAccount("default", {
+  apiKey: "my_api_key",
+  defaultSender: "sender@example.com",
+});
 ```
 
 Or via the HTTP API:
@@ -162,24 +189,72 @@ Content-Type: application/json
 
 ---
 
+## Registering a custom recipient type
+
+A recipient type is a named, reusable JSON Schema describing the shape of **one** recipient entry (e.g. `{ to: "…" }`). Providers reference recipient types by name in `acceptedRecipientTypes` instead of each declaring their own schema — this is what lets the `hermes:listRecipientTypes` action work across every provider.
+
+```typescript
+import {
+  RecipientTypeDefinition,
+  HermesMessengerPlugin,
+} from "kuzzle-plugin-hermes-messenger";
+
+const webhookUrlRecipient: RecipientTypeDefinition = {
+  name: "webhookUrl", // unique registry key, referenced by acceptedRecipientTypes
+  type: "webhook", // coarse category; several `name`s may share the same `type`
+  description: "An HTTP endpoint to POST the message to",
+  jsonSchema: {
+    type: "object",
+    properties: {
+      to: { type: "string", format: "uri", title: "Webhook URL" },
+    },
+    required: ["to"],
+  },
+};
+
+const plugin = new HermesMessengerPlugin();
+
+// Must be registered before any provider that lists 'webhookUrl' in its
+// acceptedRecipientTypes.
+plugin.registerRecipientType(webhookUrlRecipient);
+```
+
+Notes:
+
+- Registering the same `name` twice with an identical definition is a no-op; registering it twice with a **different** `type`/`jsonSchema` throws a `BadRequestError`.
+- `recipientTypeRegistry.get(name)` / `.has(name)` / `.list()` are available wherever the registry is passed (providers, controllers) to look up or enumerate definitions at runtime.
+- `hermes:listRecipientTypes` (`GET /_/hermes/recipient-types`) exposes every registered `RecipientTypeDefinition` over the API.
+
+---
+
 ## BaseProvider API reference
 
-| Method | Description |
-|---|---|
-| `addAccount(name, ...args)` | Register an account; triggers cluster sync |
-| `removeAccount(name)` | Remove a registered account |
-| `getAccount(name)` | Retrieve a registered account (throws if not found) |
-| `listAccounts()` | Returns `[{ name, options }]` for all accounts |
-| `validateParams(params)` | Validate against `paramsJsonSchema` |
-| `validateRecipients(recipients)` | Validate against `recipientsJsonSchema` |
-| `validateContent(content)` | Validate against `contentJsonSchema` |
-| `getName()` | Returns the provider name |
+| Method                                              | Description                                                                                                                                                                                                                            |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `addAccount(name, params)`                          | Register an account; triggers cluster sync                                                                                                                                                                                             |
+| `removeAccount(name)`                               | Remove a registered account                                                                                                                                                                                                            |
+| `getAccount(name)`                                  | Retrieve a registered account (throws if not found)                                                                                                                                                                                    |
+| `listAccounts()`                                    | Returns `[{ name, options }]` for all accounts                                                                                                                                                                                         |
+| `getAcceptedRecipientTypes()`                       | Returns the `recipientType` names this provider accepts                                                                                                                                                                                |
+| `validateParams(params)`                            | Validate against `paramsJsonSchema`                                                                                                                                                                                                    |
+| `validateRecipients(recipient, recipientTypeName?)` | Validate one recipient against the named type's schema; if the provider accepts only one type, `recipientTypeName` can be omitted                                                                                                      |
+| `validateContent(content)`                          | Validate against `contentJsonSchema`                                                                                                                                                                                                   |
+| `validateSendParams(params)`                        | Validate against `sendParamsJsonSchema`                                                                                                                                                                                                |
+| `getName()`                                         | Returns the provider name                                                                                                                                                                                                              |
+| `serialize()`                                       | Returns a `SerializedProvider` (`name`, `type`, `supportAttachment`, `messageType`, `acceptedRecipientTypes`, `paramsJsonSchema`, `contentJsonSchema`, `sendParamsJsonSchema`) — what `hermes:listProviders` returns for each provider |
+
+### Public properties
+
+| Property            | Description                                                                                                      |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `supportAttachment` | Whether this provider supports attachments (default `false`)                                                     |
+| `messageType`       | `"short"` or `"long"` (default `"short"`) — lets `hermes:listProviders` be filtered by message length capability |
 
 ### Protected properties available in `send()` and `sendMessage()`
 
-| Property | Description |
-|---|---|
-| `this.context` | Kuzzle plugin context |
-| `this.config` | Plugin configuration (includes `adminIndex`, `mockedAccounts`) |
-| `this.sdk` | Kuzzle embedded SDK shortcut |
-| `this.cluster` | Kuzzle cluster accessor |
+| Property       | Description                                                    |
+| -------------- | -------------------------------------------------------------- |
+| `this.context` | Kuzzle plugin context                                          |
+| `this.config`  | Plugin configuration (includes `adminIndex`, `mockedAccounts`) |
+| `this.sdk`     | Kuzzle embedded SDK shortcut                                   |
+| `this.cluster` | Kuzzle cluster accessor                                        |

--- a/doc/2/guides/custom-provider/index.md
+++ b/doc/2/guides/custom-provider/index.md
@@ -201,7 +201,6 @@ import {
 
 const webhookUrlRecipient: RecipientTypeDefinition = {
   name: "webhookUrl", // unique registry key, referenced by acceptedRecipientTypes
-  type: "webhook", // coarse category; several `name`s may share the same `type`
   description: "An HTTP endpoint to POST the message to",
   jsonSchema: {
     type: "object",
@@ -221,7 +220,7 @@ plugin.registerRecipientType(webhookUrlRecipient);
 
 Notes:
 
-- Registering the same `name` twice with an identical definition is a no-op; registering it twice with a **different** `type`/`jsonSchema` throws a `BadRequestError`.
+- Registering the same `name` twice with an identical definition is a no-op;
 - `recipientTypeRegistry.get(name)` / `.has(name)` / `.list()` are available wherever the registry is passed (providers, controllers) to look up or enumerate definitions at runtime.
 - `hermes:listRecipientTypes` (`GET /_/hermes/recipient-types`) exposes every registered `RecipientTypeDefinition` over the API.
 

--- a/doc/2/guides/custom-provider/index.md
+++ b/doc/2/guides/custom-provider/index.md
@@ -36,15 +36,19 @@ interface MyAccount extends BaseAccount<MyClient> {
 ```typescript
 import {
   BaseProvider,
-  ProviderType,
+  ProviderCapabilities,
   RecipientTypeRegistry,
 } from "kuzzle-plugin-hermes-messenger";
 import { JSONSchema7 } from "json-schema";
 
 export class MyProvider extends BaseProvider<MyAccount> {
-  // Optional overrides — defaults are `false` / `"short"`.
-  override supportAttachment = false;
-  override messageType: "short" | "long" = "short";
+  // Declares what this provider supports — defaults are all `false`.
+  override capabilities: ProviderCapabilities = {
+    fileAttachment: false,
+    shortMessage: true,
+    longMessage: false,
+    json: false,
+  };
 
   constructor(recipientTypeRegistry: RecipientTypeRegistry) {
     // paramsJsonSchema: shape of the credentials passed to addAccount
@@ -76,7 +80,6 @@ export class MyProvider extends BaseProvider<MyAccount> {
 
     super(
       "my-provider",
-      ProviderType.SMS,
       ["phoneNumber"], // acceptedRecipientTypes — must already be registered, see below
       paramsJsonSchema,
       contentJsonSchema,
@@ -228,26 +231,25 @@ Notes:
 
 ## BaseProvider API reference
 
-| Method                                              | Description                                                                                                                                                                                                                            |
-| --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `addAccount(name, params)`                          | Register an account; triggers cluster sync                                                                                                                                                                                             |
-| `removeAccount(name)`                               | Remove a registered account                                                                                                                                                                                                            |
-| `getAccount(name)`                                  | Retrieve a registered account (throws if not found)                                                                                                                                                                                    |
-| `listAccounts()`                                    | Returns `[{ name, options }]` for all accounts                                                                                                                                                                                         |
-| `getAcceptedRecipientTypes()`                       | Returns the `recipientType` names this provider accepts                                                                                                                                                                                |
-| `validateParams(params)`                            | Validate against `paramsJsonSchema`                                                                                                                                                                                                    |
-| `validateRecipients(recipient, recipientTypeName?)` | Validate one recipient against the named type's schema; if the provider accepts only one type, `recipientTypeName` can be omitted                                                                                                      |
-| `validateContent(content)`                          | Validate against `contentJsonSchema`                                                                                                                                                                                                   |
-| `validateSendParams(params)`                        | Validate against `sendParamsJsonSchema`                                                                                                                                                                                                |
-| `getName()`                                         | Returns the provider name                                                                                                                                                                                                              |
-| `serialize()`                                       | Returns a `SerializedProvider` (`name`, `type`, `supportAttachment`, `messageType`, `acceptedRecipientTypes`, `paramsJsonSchema`, `contentJsonSchema`, `sendParamsJsonSchema`) — what `hermes:listProviders` returns for each provider |
+| Method                                              | Description                                                                                                                                                                                                       |
+| --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `addAccount(name, params)`                          | Register an account; triggers cluster sync                                                                                                                                                                        |
+| `removeAccount(name)`                               | Remove a registered account                                                                                                                                                                                       |
+| `getAccount(name)`                                  | Retrieve a registered account (throws if not found)                                                                                                                                                               |
+| `listAccounts()`                                    | Returns `[{ name, options }]` for all accounts                                                                                                                                                                    |
+| `getAcceptedRecipientTypes()`                       | Returns the `recipientType` names this provider accepts                                                                                                                                                           |
+| `validateAccountParams(params)`                     | Validate against `accountParamsJsonSchema`                                                                                                                                                                        |
+| `validateRecipients(recipient, recipientTypeName?)` | Validate one recipient against the named type's schema; if the provider accepts only one type, `recipientTypeName` can be omitted                                                                                 |
+| `validateContent(content)`                          | Validate against `contentJsonSchema`                                                                                                                                                                              |
+| `validateSendParams(params)`                        | Validate against `sendParamsJsonSchema`                                                                                                                                                                           |
+| `getName()`                                         | Returns the provider name                                                                                                                                                                                         |
+| `serialize()`                                       | Returns a `SerializedProvider` (`name`, `capabilities`, `acceptedRecipientTypes`, `accountParamsJsonSchema`, `contentJsonSchema`, `sendParamsJsonSchema`) — what `hermes:listProviders` returns for each provider |
 
 ### Public properties
 
-| Property            | Description                                                                                                      |
-| ------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `supportAttachment` | Whether this provider supports attachments (default `false`)                                                     |
-| `messageType`       | `"short"` or `"long"` (default `"short"`) — lets `hermes:listProviders` be filtered by message length capability |
+| Property       | Description                                                                                                                                                                                                                               |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `capabilities` | A `ProviderCapabilities` object declaring what this provider supports — `fileAttachment`, `shortMessage`, `longMessage`, `json` (all default `false`). Exposed via `serialize()` so `hermes:listProviders` can be filtered by capability. |
 
 ### Protected properties available in `send()` and `sendMessage()`
 

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,1 @@
-export * from "./lib/HermesMessengerPlugin";
-
-export * from "./lib/providers";
-
-export * from "./lib/types";
+export * from "./lib/exports";

--- a/lib/HermesMessengerPlugin.ts
+++ b/lib/HermesMessengerPlugin.ts
@@ -36,17 +36,33 @@ export class ProviderManager {
   }
 
   get(providerName: string): BaseProvider<any> {
-    if (!this.providers.has(providerName)) {
+    const provider = this.providers.get(providerName);
+    if (!provider) {
       throw new InternalError(
         `${providerName} provider is not available yet. Are you trying to access it before the application has started ?`,
       );
     }
 
-    return this.providers.get(providerName);
+    return provider;
   }
 
-  listProviders(): BaseProvider<any>[] {
-    return Array.from(this.providers.values());
+  listProviders(filter?: {
+    supportAttachment?: boolean;
+    messageType?: "short" | "long";
+  }): BaseProvider<any>[] {
+    let providers = Array.from(this.providers.values());
+
+    if (filter?.supportAttachment !== undefined) {
+      providers = providers.filter(
+        (p) => p.supportAttachment === filter.supportAttachment,
+      );
+    }
+
+    if (filter?.messageType !== undefined) {
+      providers = providers.filter((p) => p.messageType === filter.messageType);
+    }
+
+    return providers;
   }
 }
 

--- a/lib/HermesMessengerPlugin.ts
+++ b/lib/HermesMessengerPlugin.ts
@@ -1,76 +1,34 @@
 import {
-  InternalError,
+  BadRequestError,
   JSONObject,
+  KuzzleError,
   Mutex,
   Plugin,
   PluginContext,
 } from "kuzzle";
-import _ from "lodash";
+import merge from "lodash/merge";
 
 import { ProviderController } from "./controllers";
 import {
   BaseProvider,
+  ProviderManager,
   SendgridProvider,
   SMSEnvoiProvider,
   SmtpProvider,
   TwilioProvider,
 } from "./providers";
-
-export class ProviderManager {
-  private providers = new Map<string, BaseProvider<any>>();
-
-  constructor() {}
-
-  async init(config: JSONObject, context: PluginContext): Promise<void> {
-    for (const [, value] of this.providers) {
-      await value.init(config, context);
-    }
-  }
-
-  set(providerName: string, providerInstance: BaseProvider<any>) {
-    this.providers.set(providerName, providerInstance);
-  }
-
-  has(providerName: string): boolean {
-    return this.providers.has(providerName);
-  }
-
-  get(providerName: string): BaseProvider<any> {
-    const provider = this.providers.get(providerName);
-    if (!provider) {
-      throw new InternalError(
-        `${providerName} provider is not available yet. Are you trying to access it before the application has started ?`,
-      );
-    }
-
-    return provider;
-  }
-
-  listProviders(filter?: {
-    supportAttachment?: boolean;
-    messageType?: "short" | "long";
-  }): BaseProvider<any>[] {
-    let providers = Array.from(this.providers.values());
-
-    if (filter?.supportAttachment !== undefined) {
-      providers = providers.filter(
-        (p) => p.supportAttachment === filter.supportAttachment,
-      );
-    }
-
-    if (filter?.messageType !== undefined) {
-      providers = providers.filter((p) => p.messageType === filter.messageType);
-    }
-
-    return providers;
-  }
-}
-
+import {
+  emailRecipient,
+  phoneRecipient,
+  RecipientTypeDefinition,
+  RecipientTypeRegistry,
+} from "./recipients";
 export class HermesMessengerPlugin extends Plugin {
-  private defaultConfig: JSONObject;
-  private controller: ProviderController;
-  private providerManager: ProviderManager;
-
+  readonly defaultConfig: JSONObject;
+  readonly controller: ProviderController;
+  readonly providerManager: ProviderManager;
+  readonly recipientTypeRegistry: RecipientTypeRegistry =
+    new RecipientTypeRegistry();
   constructor() {
     super({
       kuzzleVersion: ">=2.12.0 <3",
@@ -94,15 +52,30 @@ export class HermesMessengerPlugin extends Plugin {
     };
 
     this.providerManager = new ProviderManager();
-    this.providerManager.set("smtp", new SmtpProvider());
-    this.providerManager.set("twilio", new TwilioProvider());
-    this.providerManager.set("sendgrid", new SendgridProvider());
-    this.providerManager.set("smsenvoi", new SMSEnvoiProvider());
+
+    this.registerRecipientType(emailRecipient);
+
+    this.registerRecipientType(phoneRecipient);
+
+    this.registerProvider("smtp", new SmtpProvider(this.recipientTypeRegistry));
+    this.registerProvider(
+      "twilio",
+      new TwilioProvider(this.recipientTypeRegistry),
+    );
+    this.registerProvider(
+      "sendgrid",
+      new SendgridProvider(this.recipientTypeRegistry),
+    );
+    this.registerProvider(
+      "smsenvoi",
+      new SMSEnvoiProvider(this.recipientTypeRegistry),
+    );
 
     this.controller = new ProviderController(
       this.config,
       this.context,
       this.providerManager,
+      this.recipientTypeRegistry,
     );
   }
 
@@ -114,7 +87,7 @@ export class HermesMessengerPlugin extends Plugin {
    * Init the plugin
    */
   async init(config: JSONObject, context: PluginContext) {
-    this.config = _.merge(this.defaultConfig, config);
+    this.config = merge(this.defaultConfig, config);
 
     this.context = context;
 
@@ -129,6 +102,14 @@ export class HermesMessengerPlugin extends Plugin {
   }
 
   registerProvider(name: string, provider: BaseProvider<any>) {
+    for (const recipientTypeName of provider.getAcceptedRecipientTypes()) {
+      if (!this.recipientTypeRegistry.has(recipientTypeName)) {
+        throw new BadRequestError(
+          `Provider "${name}" references unknown recipient type "${recipientTypeName}" — register it via registerRecipientType() before registering this provider.`,
+        );
+      }
+    }
+
     this.providerManager.set(name, provider);
   }
 
@@ -138,6 +119,22 @@ export class HermesMessengerPlugin extends Plugin {
 
   getProvider(name: string) {
     return this.providerManager.get(name);
+  }
+
+  registerRecipientType(definition: RecipientTypeDefinition): void {
+    this.recipientTypeRegistry.register(definition);
+  }
+
+  hasRecipientType(name: string): boolean {
+    return this.recipientTypeRegistry.has(name);
+  }
+
+  getRecipientType(name: string): RecipientTypeDefinition {
+    return this.recipientTypeRegistry.get(name);
+  }
+
+  listRecipientTypes(): RecipientTypeDefinition[] {
+    return this.recipientTypeRegistry.list();
   }
 
   private async initDatabase() {
@@ -153,7 +150,10 @@ export class HermesMessengerPlugin extends Plugin {
         try {
           await this.sdk.index.create(this.config.adminIndex);
         } catch (error) {
-          if (error.id !== "services.storage.index_already_exists") {
+          if (
+            (error as KuzzleError).id !==
+            "services.storage.index_already_exists"
+          ) {
             throw error;
           }
         }

--- a/lib/controllers/ProviderController.ts
+++ b/lib/controllers/ProviderController.ts
@@ -5,13 +5,15 @@ import {
   PluginContext,
   ControllerDefinition,
 } from "kuzzle";
-import { ProviderManager } from "lib/HermesMessengerPlugin";
+import { ProviderManager } from "../..";
+import { RecipientTypeRegistry } from "../recipients";
 
 export class ProviderController {
   protected context: PluginContext;
-  private config: JSONObject;
+  readonly config: JSONObject;
 
-  private providerManager: ProviderManager;
+  readonly providerManager: ProviderManager;
+  readonly recipientTypeRegistry: RecipientTypeRegistry;
 
   definition: ControllerDefinition;
 
@@ -23,10 +25,12 @@ export class ProviderController {
     config: JSONObject,
     context: PluginContext,
     providerManager: ProviderManager,
+    recipientTypeRegistry: RecipientTypeRegistry,
   ) {
     this.config = config;
     this.context = context;
     this.providerManager = providerManager;
+    this.recipientTypeRegistry = recipientTypeRegistry;
 
     this.definition = {
       actions: {
@@ -59,6 +63,10 @@ export class ProviderController {
         listProviders: {
           handler: this.listProviders.bind(this),
           http: [{ verb: "get", path: `hermes/providers` }],
+        },
+        listRecipientTypes: {
+          handler: this.listRecipientTypes.bind(this),
+          http: [{ verb: "get", path: `hermes/recipient-types` }],
         },
       },
     };
@@ -102,5 +110,9 @@ export class ProviderController {
   async listProviders(request: KuzzleRequest) {
     const filters = request.getBodyObject("filters", {});
     return this.providerManager.listProviders(filters);
+  }
+
+  async listRecipientTypes() {
+    return this.recipientTypeRegistry.list();
   }
 }

--- a/lib/controllers/ProviderController.ts
+++ b/lib/controllers/ProviderController.ts
@@ -5,8 +5,8 @@ import {
   PluginContext,
   ControllerDefinition,
 } from "kuzzle";
-import { ProviderManager } from "../..";
 import { RecipientTypeRegistry } from "../recipients";
+import { ProviderManager } from "../providers";
 
 export class ProviderController {
   protected context: PluginContext;
@@ -109,7 +109,9 @@ export class ProviderController {
 
   async listProviders(request: KuzzleRequest) {
     const filters = request.getBodyObject("filters", {});
-    return this.providerManager.listProviders(filters);
+    const providers = this.providerManager.listProviders(filters);
+
+    return providers.map((provider) => provider.serialize());
   }
 
   async listRecipientTypes() {

--- a/lib/controllers/ProviderController.ts
+++ b/lib/controllers/ProviderController.ts
@@ -99,7 +99,8 @@ export class ProviderController {
     return { accounts };
   }
 
-  async listProviders() {
-    return this.providerManager.listProviders();
+  async listProviders(request: KuzzleRequest) {
+    const filters = request.getBodyObject("filters", {});
+    return this.providerManager.listProviders(filters);
   }
 }

--- a/lib/exports.ts
+++ b/lib/exports.ts
@@ -1,0 +1,4 @@
+export * from "./HermesMessengerPlugin";
+export * from "./providers";
+export * from "./recipients";
+export * from "./types";

--- a/lib/providers/BaseProvider.ts
+++ b/lib/providers/BaseProvider.ts
@@ -11,6 +11,7 @@ import {
   NotFoundError,
   PluginContext,
 } from "kuzzle";
+import { MessageType } from "../..";
 
 export enum ProviderType {
   EMAIL = "email",

--- a/lib/providers/BaseProvider.ts
+++ b/lib/providers/BaseProvider.ts
@@ -126,7 +126,7 @@ export abstract class BaseProvider<T> {
     return this.name;
   }
 
-  getParamsJsonSchema(): JSONSchema7 {
+  getAccountParamsJsonSchema(): JSONSchema7 {
     return this.accountParamsJsonSchema;
   }
 

--- a/lib/providers/BaseProvider.ts
+++ b/lib/providers/BaseProvider.ts
@@ -35,6 +35,7 @@ export abstract class BaseProvider<T> {
   protected accounts = new Map<string, T>();
 
   public supportAttachment: boolean = false;
+  public messageType: "short" | "long" = "short";
 
   protected EVENT_ACCOUNT_ADD: string;
   protected EVENT_ACCOUNT_REMOVE: string;

--- a/lib/providers/BaseProvider.ts
+++ b/lib/providers/BaseProvider.ts
@@ -13,6 +13,7 @@ import {
 } from "kuzzle";
 import { MessageType } from "../..";
 import { RecipientTypeRegistry } from "../recipients";
+import { SerializedProvider } from "../types";
 
 export enum ProviderType {
   EMAIL = "email",
@@ -134,6 +135,19 @@ export abstract class BaseProvider<T> {
 
   getAcceptedRecipientTypes(): string[] {
     return this.acceptedRecipientTypes;
+  }
+
+  serialize(): SerializedProvider {
+    return {
+      name: this.name,
+      type: this.type,
+      supportAttachment: this.supportAttachment,
+      messageType: this.messageType,
+      acceptedRecipientTypes: this.acceptedRecipientTypes,
+      paramsJsonSchema: this.paramsJsonSchema,
+      contentJsonSchema: this.contentJsonSchema,
+      sendParamsJsonSchema: this.sendParamsJsonSchema,
+    };
   }
 
   abstract send(

--- a/lib/providers/BaseProvider.ts
+++ b/lib/providers/BaseProvider.ts
@@ -12,6 +12,7 @@ import {
   PluginContext,
 } from "kuzzle";
 import { MessageType } from "../..";
+import { RecipientTypeRegistry } from "../recipients";
 
 export enum ProviderType {
   EMAIL = "email",
@@ -41,11 +42,10 @@ export abstract class BaseProvider<T> {
   protected EVENT_ACCOUNT_ADD: string;
   protected EVENT_ACCOUNT_REMOVE: string;
 
+  protected acceptedRecipientTypes: string[];
+
   protected paramsJsonSchema: JSONSchema7;
   protected paramsJsonSchemaValidator: ValidateFunction;
-
-  protected recipientsJsonSchema: JSONSchema7;
-  protected recipientsJsonSchemaValidator: ValidateFunction;
 
   protected contentJsonSchema: JSONSchema7;
   protected contentJsonSchemaValidator: ValidateFunction;
@@ -53,6 +53,10 @@ export abstract class BaseProvider<T> {
   protected sendParamsJsonSchema: JSONSchema7;
   protected sendParamsJsonSchemaValidator: ValidateFunction;
 
+  private ajv: Ajv;
+  private recipientJsonSchemaValidators = new Map<string, ValidateFunction>();
+
+  private recipientTypeRegistry: RecipientTypeRegistry;
   get sdk() {
     return this.context.accessors.sdk;
   }
@@ -64,25 +68,31 @@ export abstract class BaseProvider<T> {
   constructor(
     name: string,
     type: ProviderType,
+    acceptedRecipientTypes: string[],
     paramsJsonSchema: JSONSchema7,
-    recipientsJsonSchema: JSONSchema7,
     contentJsonSchema: JSONSchema7,
     sendParamsJsonSchema: JSONSchema7 = {},
+    recipientTypeRegistry: RecipientTypeRegistry,
   ) {
     this.name = name;
     this.type = type;
+    this.acceptedRecipientTypes = acceptedRecipientTypes;
     this.paramsJsonSchema = paramsJsonSchema;
-    this.recipientsJsonSchema = recipientsJsonSchema;
     this.contentJsonSchema = contentJsonSchema;
     this.sendParamsJsonSchema = sendParamsJsonSchema;
-
-    const ajv = new Ajv();
-    addFormats(ajv);
-    this.paramsJsonSchemaValidator = ajv.compile(this.paramsJsonSchema);
-    this.recipientsJsonSchemaValidator = ajv.compile(this.recipientsJsonSchema);
-    this.contentJsonSchemaValidator = ajv.compile(this.contentJsonSchema);
-    this.sendParamsJsonSchemaValidator = ajv.compile(this.sendParamsJsonSchema);
-
+    this.recipientTypeRegistry = recipientTypeRegistry;
+    this.ajv = new Ajv();
+    addFormats(this.ajv);
+    this.paramsJsonSchemaValidator = this.ajv.compile(this.paramsJsonSchema);
+    this.contentJsonSchemaValidator = this.ajv.compile(this.contentJsonSchema);
+    this.sendParamsJsonSchemaValidator = this.ajv.compile(
+      this.sendParamsJsonSchema,
+    );
+    for (const recipientTypeName of this.acceptedRecipientTypes) {
+      const definition = this.recipientTypeRegistry.get(recipientTypeName);
+      const validator = this.ajv.compile(definition.jsonSchema);
+      this.recipientJsonSchemaValidators.set(recipientTypeName, validator);
+    }
     this.EVENT_ACCOUNT_ADD = `${this.name}:account:add`;
     this.EVENT_ACCOUNT_REMOVE = `${this.name}:account:remove`;
   }
@@ -120,6 +130,10 @@ export abstract class BaseProvider<T> {
 
   getParamsJsonSchema(): JSONSchema7 {
     return this.paramsJsonSchema;
+  }
+
+  getAcceptedRecipientTypes(): string[] {
+    return this.acceptedRecipientTypes;
   }
 
   abstract send(
@@ -166,8 +180,12 @@ export abstract class BaseProvider<T> {
     const valid = this.paramsJsonSchemaValidator(params);
 
     if (valid === false) {
-      const errors = this.paramsJsonSchemaValidator.errors.map(
-        (e) => new KuzzleError(e.message, 400),
+      const errors = (this.paramsJsonSchemaValidator?.errors ?? []).map(
+        (e) =>
+          new KuzzleError(
+            e?.message ?? "An error occured with the param validation schema",
+            400,
+          ),
       );
       throw new MultipleErrorsError(
         "Parameters format does not match with the json schema defined in the provider",
@@ -176,26 +194,72 @@ export abstract class BaseProvider<T> {
     }
   }
 
-  validateRecipients(recipients: JSONObject): void {
-    const valid = this.recipientsJsonSchemaValidator(recipients);
+  validateRecipients(recipient: unknown, recipientTypeName?: string): void {
+    const resolvedTypeName = this.resolveRecipientTypeName(recipientTypeName);
+    const validator = this.getRecipientJsonSchemaValidator(resolvedTypeName);
+
+    const valid = validator(recipient);
 
     if (valid === false) {
-      const errors = this.recipientsJsonSchemaValidator.errors.map(
-        (e) => new KuzzleError(e.message, 400),
+      const errors = (validator?.errors ?? []).map(
+        (e) =>
+          new KuzzleError(
+            e?.message ??
+              "An error occured with the recipient validation schema",
+            400,
+          ),
       );
       throw new MultipleErrorsError(
-        "Recipients format does not match with the json schema defined in the provider",
+        `Recipient format does not match with the json schema defined for recipient type "${resolvedTypeName}"`,
         errors,
       );
     }
+  }
+
+  private resolveRecipientTypeName(recipientTypeName?: string): string {
+    if (recipientTypeName) {
+      if (!this.acceptedRecipientTypes.includes(recipientTypeName)) {
+        throw new BadRequestError(
+          `${Inflector.upFirst(this.name)} does not accept recipient type "${recipientTypeName}" (accepted: ${this.acceptedRecipientTypes.join(", ")}).`,
+        );
+      }
+
+      return recipientTypeName;
+    }
+
+    if (this.acceptedRecipientTypes.length === 1) {
+      return this.acceptedRecipientTypes[0];
+    }
+
+    throw new BadRequestError(
+      `${Inflector.upFirst(this.name)} accepts multiple recipient types (${this.acceptedRecipientTypes.join(", ")}); recipientTypeName must be specified explicitly.`,
+    );
+  }
+
+  private getRecipientJsonSchemaValidator(
+    recipientTypeName: string,
+  ): ValidateFunction {
+    const validator = this.recipientJsonSchemaValidators.get(recipientTypeName);
+
+    if (!validator) {
+      throw new NotFoundError(
+        `Could not retrieve recipient validator for recipient type "${recipientTypeName}"`,
+      );
+    }
+
+    return validator;
   }
 
   validateContent(content: JSONObject): void {
     const valid = this.contentJsonSchemaValidator(content);
 
     if (valid === false) {
-      const errors = this.contentJsonSchemaValidator.errors.map(
-        (e) => new KuzzleError(e.message, 400),
+      const errors = (this.contentJsonSchemaValidator?.errors ?? []).map(
+        (e) =>
+          new KuzzleError(
+            e.message ?? "An error occured with the content validation schema",
+            400,
+          ),
       );
       throw new MultipleErrorsError(
         "Content format does not match with the json schema defined in the provider",
@@ -208,8 +272,12 @@ export abstract class BaseProvider<T> {
     const valid = this.sendParamsJsonSchemaValidator(params);
 
     if (valid === false) {
-      const errors = this.sendParamsJsonSchemaValidator.errors.map(
-        (e) => new KuzzleError(e.message, 400),
+      const errors = (this.sendParamsJsonSchemaValidator?.errors ?? []).map(
+        (e) =>
+          new KuzzleError(
+            e.message ?? "An error occured with send params validation schema",
+            400,
+          ),
       );
       throw new MultipleErrorsError(
         "Send params format does not match with the json schema defined in the provider",
@@ -267,7 +335,7 @@ export abstract class BaseProvider<T> {
       throw new NotFoundError(`Account "${accountName}" does not exists.`);
     }
 
-    return this.accounts.get(accountName);
+    return this.accounts.get(accountName) as T;
   }
 
   private logInfo(message: string) {

--- a/lib/providers/BaseProvider.ts
+++ b/lib/providers/BaseProvider.ts
@@ -11,14 +11,8 @@ import {
   NotFoundError,
   PluginContext,
 } from "kuzzle";
-import { MessageType } from "../..";
 import { RecipientTypeRegistry } from "../recipients";
-import { SerializedProvider } from "../types";
-
-export enum ProviderType {
-  EMAIL = "email",
-  SMS = "sms",
-}
+import { ProviderCapabilities, SerializedProvider } from "../types";
 
 export interface BaseAccount<T> {
   provider: T;
@@ -33,20 +27,23 @@ export abstract class BaseProvider<T> {
   protected context: PluginContext;
 
   protected name: string;
-  protected type: ProviderType;
 
   protected accounts = new Map<string, T>();
 
-  public supportAttachment: boolean = false;
-  public messageType: MessageType = "short";
+  public capabilities: ProviderCapabilities = {
+    fileAttachment: false,
+    longMessage: false,
+    shortMessage: false,
+    json: false,
+  };
 
   protected EVENT_ACCOUNT_ADD: string;
   protected EVENT_ACCOUNT_REMOVE: string;
 
   protected acceptedRecipientTypes: string[];
 
-  protected paramsJsonSchema: JSONSchema7;
-  protected paramsJsonSchemaValidator: ValidateFunction;
+  protected accountParamsJsonSchema: JSONSchema7;
+  protected accountParamsJsonSchemaValidator: ValidateFunction;
 
   protected contentJsonSchema: JSONSchema7;
   protected contentJsonSchemaValidator: ValidateFunction;
@@ -68,7 +65,6 @@ export abstract class BaseProvider<T> {
 
   constructor(
     name: string,
-    type: ProviderType,
     acceptedRecipientTypes: string[],
     paramsJsonSchema: JSONSchema7,
     contentJsonSchema: JSONSchema7,
@@ -76,15 +72,16 @@ export abstract class BaseProvider<T> {
     recipientTypeRegistry: RecipientTypeRegistry,
   ) {
     this.name = name;
-    this.type = type;
     this.acceptedRecipientTypes = acceptedRecipientTypes;
-    this.paramsJsonSchema = paramsJsonSchema;
+    this.accountParamsJsonSchema = paramsJsonSchema;
     this.contentJsonSchema = contentJsonSchema;
     this.sendParamsJsonSchema = sendParamsJsonSchema;
     this.recipientTypeRegistry = recipientTypeRegistry;
     this.ajv = new Ajv();
     addFormats(this.ajv);
-    this.paramsJsonSchemaValidator = this.ajv.compile(this.paramsJsonSchema);
+    this.accountParamsJsonSchemaValidator = this.ajv.compile(
+      this.accountParamsJsonSchema,
+    );
     this.contentJsonSchemaValidator = this.ajv.compile(this.contentJsonSchema);
     this.sendParamsJsonSchemaValidator = this.ajv.compile(
       this.sendParamsJsonSchema,
@@ -130,7 +127,7 @@ export abstract class BaseProvider<T> {
   }
 
   getParamsJsonSchema(): JSONSchema7 {
-    return this.paramsJsonSchema;
+    return this.accountParamsJsonSchema;
   }
 
   getAcceptedRecipientTypes(): string[] {
@@ -140,11 +137,9 @@ export abstract class BaseProvider<T> {
   serialize(): SerializedProvider {
     return {
       name: this.name,
-      type: this.type,
-      supportAttachment: this.supportAttachment,
-      messageType: this.messageType,
+      capabilities: this.capabilities,
       acceptedRecipientTypes: this.acceptedRecipientTypes,
-      paramsJsonSchema: this.paramsJsonSchema,
+      paramsJsonSchema: this.accountParamsJsonSchema,
       contentJsonSchema: this.contentJsonSchema,
       sendParamsJsonSchema: this.sendParamsJsonSchema,
     };
@@ -190,11 +185,11 @@ export abstract class BaseProvider<T> {
     }
   }
 
-  validateParams(params: JSONObject): void {
-    const valid = this.paramsJsonSchemaValidator(params);
+  validateAccountParams(params: JSONObject): void {
+    const valid = this.accountParamsJsonSchemaValidator(params);
 
     if (valid === false) {
-      const errors = (this.paramsJsonSchemaValidator?.errors ?? []).map(
+      const errors = (this.accountParamsJsonSchemaValidator?.errors ?? []).map(
         (e) =>
           new KuzzleError(
             e?.message ?? "An error occured with the param validation schema",

--- a/lib/providers/BaseProvider.ts
+++ b/lib/providers/BaseProvider.ts
@@ -35,7 +35,7 @@ export abstract class BaseProvider<T> {
   protected accounts = new Map<string, T>();
 
   public supportAttachment: boolean = false;
-  public messageType: "short" | "long" = "short";
+  public messageType: MessageType = "short";
 
   protected EVENT_ACCOUNT_ADD: string;
   protected EVENT_ACCOUNT_REMOVE: string;

--- a/lib/providers/ProviderManager.ts
+++ b/lib/providers/ProviderManager.ts
@@ -1,5 +1,5 @@
 import { InternalError, JSONObject, PluginContext } from "kuzzle";
-import { BaseProvider } from "../..";
+import { BaseProvider } from "./BaseProvider";
 
 export class ProviderManager {
   readonly providers = new Map<string, BaseProvider<any>>();

--- a/lib/providers/ProviderManager.ts
+++ b/lib/providers/ProviderManager.ts
@@ -1,0 +1,50 @@
+import { InternalError, JSONObject, PluginContext } from "kuzzle";
+import { BaseProvider } from "../..";
+
+export class ProviderManager {
+  readonly providers = new Map<string, BaseProvider<any>>();
+
+  async init(config: JSONObject, context: PluginContext): Promise<void> {
+    for (const [, value] of this.providers) {
+      await value.init(config, context);
+    }
+  }
+
+  set(providerName: string, providerInstance: BaseProvider<any>) {
+    this.providers.set(providerName, providerInstance);
+  }
+
+  has(providerName: string): boolean {
+    return this.providers.has(providerName);
+  }
+
+  get(providerName: string): BaseProvider<any> {
+    const provider = this.providers.get(providerName);
+    if (!provider) {
+      throw new InternalError(
+        `${providerName} provider is not available yet. Are you trying to access it before the application has started ?`,
+      );
+    }
+
+    return provider;
+  }
+
+  listProviders(filter?: {
+    supportAttachment?: boolean;
+    messageType?: "short" | "long";
+  }): BaseProvider<any>[] {
+    let providers = Array.from(this.providers.values());
+
+    if (filter?.supportAttachment !== undefined) {
+      providers = providers.filter(
+        (p) => p.supportAttachment === filter.supportAttachment,
+      );
+    }
+
+    if (filter?.messageType !== undefined) {
+      providers = providers.filter((p) => p.messageType === filter.messageType);
+    }
+
+    return providers;
+  }
+}

--- a/lib/providers/ProviderManager.ts
+++ b/lib/providers/ProviderManager.ts
@@ -1,5 +1,7 @@
 import { InternalError, JSONObject, PluginContext } from "kuzzle";
 import { BaseProvider } from "./BaseProvider";
+import { matches } from "lodash";
+import { ProviderCapabilities } from "../types";
 
 export class ProviderManager {
   readonly providers = new Map<string, BaseProvider<any>>();
@@ -29,20 +31,12 @@ export class ProviderManager {
     return provider;
   }
 
-  listProviders(filter?: {
-    supportAttachment?: boolean;
-    messageType?: "short" | "long";
-  }): BaseProvider<any>[] {
+  listProviders(filter?: Partial<ProviderCapabilities>): BaseProvider<any>[] {
     let providers = Array.from(this.providers.values());
 
-    if (filter?.supportAttachment !== undefined) {
-      providers = providers.filter(
-        (p) => p.supportAttachment === filter.supportAttachment,
-      );
-    }
-
-    if (filter?.messageType !== undefined) {
-      providers = providers.filter((p) => p.messageType === filter.messageType);
+    if (filter && Object.keys(filter).length > 0) {
+      const filterMatcher = matches(filter);
+      providers = providers.filter((p) => filterMatcher(p.capabilities));
     }
 
     return providers;

--- a/lib/providers/SMSEnvoiProvider.ts
+++ b/lib/providers/SMSEnvoiProvider.ts
@@ -96,7 +96,7 @@ export class SMSEnvoiProvider extends BaseProvider<SMSEnvoiAccount> {
       );
     } catch (error: any) {
       const errorMessage =
-        error?.response?.data?.message || error.message || error;
+        error?.response?.data?.message || error?.message || error;
       throw new ExternalServiceError(`SMSEnvoi Error: ${errorMessage}`);
     }
   }

--- a/lib/providers/SMSEnvoiProvider.ts
+++ b/lib/providers/SMSEnvoiProvider.ts
@@ -95,7 +95,8 @@ export class SMSEnvoiProvider extends BaseProvider<SMSEnvoiAccount> {
         fromNumber,
       );
     } catch (error: any) {
-      const errorMessage = error?.response?.data?.message || error.message;
+      const errorMessage =
+        error?.response?.data?.message || error.message || error;
       throw new ExternalServiceError(`SMSEnvoi Error: ${errorMessage}`);
     }
   }
@@ -162,7 +163,7 @@ export class SMSEnvoiProvider extends BaseProvider<SMSEnvoiAccount> {
       { headers },
     );
 
-    return response.data;
+    return response;
   }
 
   private async mockedAccount(accountName: string): Promise<boolean> {

--- a/lib/providers/SMSEnvoiProvider.ts
+++ b/lib/providers/SMSEnvoiProvider.ts
@@ -3,6 +3,7 @@ import axios from "axios";
 import { JSONSchema7 } from "json-schema";
 
 import { BaseAccount, BaseProvider, ProviderType } from "./BaseProvider";
+import { RecipientTypeRegistry } from "../recipients";
 
 export interface SMSEnvoiAccount extends BaseAccount<null> {
   options: {
@@ -13,7 +14,7 @@ export interface SMSEnvoiAccount extends BaseAccount<null> {
 }
 
 export class SMSEnvoiProvider extends BaseProvider<SMSEnvoiAccount> {
-  constructor() {
+  constructor(recipientTypeRegistry: RecipientTypeRegistry) {
     const paramsJsonSchema: JSONSchema7 = {
       type: "object",
       properties: {
@@ -31,18 +32,6 @@ export class SMSEnvoiProvider extends BaseProvider<SMSEnvoiAccount> {
         },
       },
       required: ["user_key", "access_token", "default_sender"],
-    };
-
-    const recipientsJsonSchema: JSONSchema7 = {
-      type: "object",
-      properties: {
-        phone: {
-          type: "string",
-          title: "Phone number",
-          pattern: String.raw`^\+[0-9]+$`,
-        },
-      },
-      required: ["phone"],
     };
 
     const contentJsonSchema: JSONSchema7 = {
@@ -66,10 +55,11 @@ export class SMSEnvoiProvider extends BaseProvider<SMSEnvoiAccount> {
     super(
       "smsenvoi",
       ProviderType.SMS,
+      ["phoneNumber"],
       paramsJsonSchema,
-      recipientsJsonSchema,
       contentJsonSchema,
       sendParamsJsonSchema,
+      recipientTypeRegistry,
     );
   }
 
@@ -85,7 +75,7 @@ export class SMSEnvoiProvider extends BaseProvider<SMSEnvoiAccount> {
 
     const account = this.getAccount(accountName);
     const fromNumber = from || account.options.defaultSender;
-    const phoneNumbers = recipients.map((recipient) => recipient.phone);
+    const phoneNumbers = recipients.map((recipient) => recipient.to);
 
     try {
       await this.sendMessage(
@@ -157,13 +147,9 @@ export class SMSEnvoiProvider extends BaseProvider<SMSEnvoiAccount> {
       sender: fromNumber,
     };
 
-    const response = await axios.post(
-      "https://api.smsenvoi.com/API/v1.0/REST/sms",
-      payload,
-      { headers },
-    );
-
-    return response;
+    await axios.post("https://api.smsenvoi.com/API/v1.0/REST/sms", payload, {
+      headers,
+    });
   }
 
   private async mockedAccount(accountName: string): Promise<boolean> {

--- a/lib/providers/SMSEnvoiProvider.ts
+++ b/lib/providers/SMSEnvoiProvider.ts
@@ -2,8 +2,9 @@ import { ExternalServiceError, NotFoundError } from "kuzzle";
 import axios from "axios";
 import { JSONSchema7 } from "json-schema";
 
-import { BaseAccount, BaseProvider, ProviderType } from "./BaseProvider";
+import { BaseAccount, BaseProvider } from "./BaseProvider";
 import { RecipientTypeRegistry } from "../recipients";
+import { ProviderCapabilities } from "../types";
 
 export interface SMSEnvoiAccount extends BaseAccount<null> {
   options: {
@@ -14,6 +15,12 @@ export interface SMSEnvoiAccount extends BaseAccount<null> {
 }
 
 export class SMSEnvoiProvider extends BaseProvider<SMSEnvoiAccount> {
+  override capabilities: ProviderCapabilities = {
+    longMessage: false,
+    shortMessage: true,
+    fileAttachment: false,
+    json: false,
+  };
   constructor(recipientTypeRegistry: RecipientTypeRegistry) {
     const paramsJsonSchema: JSONSchema7 = {
       type: "object",
@@ -54,7 +61,6 @@ export class SMSEnvoiProvider extends BaseProvider<SMSEnvoiAccount> {
 
     super(
       "smsenvoi",
-      ProviderType.SMS,
       ["phoneNumber"],
       paramsJsonSchema,
       contentJsonSchema,

--- a/lib/providers/SendgridProvider.ts
+++ b/lib/providers/SendgridProvider.ts
@@ -47,7 +47,7 @@ export class SendgridProvider extends BaseProvider<SendgridAccount> {
         message: {
           type: "string",
           title: "Message",
-          format: "long-text",
+          $comment: "long-text",
         },
       },
       required: ["subject", "message"],
@@ -57,6 +57,14 @@ export class SendgridProvider extends BaseProvider<SendgridAccount> {
       type: "object",
       properties: {
         from: { type: "string" },
+        cc: {
+          type: "string",
+          title: "Cc",
+        },
+        bcc: {
+          type: "string",
+          title: "Bcc",
+        },
         attachments: {
           type: "array",
           items: {
@@ -97,7 +105,17 @@ export class SendgridProvider extends BaseProvider<SendgridAccount> {
     accountName: string,
     recipients: any[],
     content: any,
-    { from, attachments }: { from?: string; attachments?: Attachment[] } = {},
+    {
+      from,
+      attachments,
+      cc,
+      bcc,
+    }: {
+      from?: string;
+      attachments?: Attachment[];
+      cc?: string;
+      bcc?: string;
+    } = {},
   ): Promise<void> {
     const account = this.getAccount(accountName);
     const fromEmail = from || account.options.defaultSender;
@@ -106,6 +124,8 @@ export class SendgridProvider extends BaseProvider<SendgridAccount> {
     const email = {
       from: fromEmail,
       to,
+      cc,
+      bcc,
       subject: content.subject,
       html: content.message,
       attachments: attachments?.map(

--- a/lib/providers/SendgridProvider.ts
+++ b/lib/providers/SendgridProvider.ts
@@ -2,8 +2,8 @@ import { ExternalServiceError } from "kuzzle";
 import { MailService } from "@sendgrid/mail";
 import { JSONSchema7 } from "json-schema";
 
-import { Attachment, SendgridAttachment } from "../types";
-import { BaseAccount, BaseProvider, ProviderType } from "./BaseProvider";
+import { Attachment, ProviderCapabilities, SendgridAttachment } from "../types";
+import { BaseAccount, BaseProvider } from "./BaseProvider";
 import { RecipientTypeRegistry } from "../recipients";
 
 export interface SendgridAccount extends BaseAccount<MailService> {
@@ -13,8 +13,12 @@ export interface SendgridAccount extends BaseAccount<MailService> {
 }
 
 export class SendgridProvider extends BaseProvider<SendgridAccount> {
-  override supportAttachment = true;
-  override messageType: "short" | "long" = "long";
+  override capabilities: ProviderCapabilities = {
+    longMessage: true,
+    shortMessage: true,
+    fileAttachment: true,
+    json: false,
+  };
 
   constructor(recipientTypeRegistry: RecipientTypeRegistry) {
     const paramsJsonSchema: JSONSchema7 = {
@@ -92,7 +96,6 @@ export class SendgridProvider extends BaseProvider<SendgridAccount> {
 
     super(
       "sendgrid",
-      ProviderType.EMAIL,
       ["email"],
       paramsJsonSchema,
       contentJsonSchema,

--- a/lib/providers/SendgridProvider.ts
+++ b/lib/providers/SendgridProvider.ts
@@ -13,6 +13,7 @@ export interface SendgridAccount extends BaseAccount<MailService> {
 
 export class SendgridProvider extends BaseProvider<SendgridAccount> {
   override supportAttachment = true;
+  override messageType: "short" | "long" = "long";
 
   constructor() {
     const paramsJsonSchema: JSONSchema7 = {

--- a/lib/providers/SendgridProvider.ts
+++ b/lib/providers/SendgridProvider.ts
@@ -4,6 +4,7 @@ import { JSONSchema7 } from "json-schema";
 
 import { Attachment, SendgridAttachment } from "../types";
 import { BaseAccount, BaseProvider, ProviderType } from "./BaseProvider";
+import { RecipientTypeRegistry } from "../recipients";
 
 export interface SendgridAccount extends BaseAccount<MailService> {
   options: {
@@ -15,7 +16,7 @@ export class SendgridProvider extends BaseProvider<SendgridAccount> {
   override supportAttachment = true;
   override messageType: "short" | "long" = "long";
 
-  constructor() {
+  constructor(recipientTypeRegistry: RecipientTypeRegistry) {
     const paramsJsonSchema: JSONSchema7 = {
       type: "object",
       properties: {
@@ -36,18 +37,6 @@ export class SendgridProvider extends BaseProvider<SendgridAccount> {
       required: ["api_key", "default_sender"],
     };
 
-    const recipientsJsonSchema: JSONSchema7 = {
-      type: "object",
-      properties: {
-        to: {
-          type: "string",
-          title: "Email",
-          pattern: String.raw`^[\w._%+-]+@[\w.-]+\.[a-zA-Z]{2,}$`,
-        },
-      },
-      required: ["to"],
-    };
-
     const contentJsonSchema: JSONSchema7 = {
       type: "object",
       properties: {
@@ -58,6 +47,7 @@ export class SendgridProvider extends BaseProvider<SendgridAccount> {
         message: {
           type: "string",
           title: "Message",
+          format: "long-text",
         },
       },
       required: ["subject", "message"],
@@ -95,10 +85,11 @@ export class SendgridProvider extends BaseProvider<SendgridAccount> {
     super(
       "sendgrid",
       ProviderType.EMAIL,
+      ["email"],
       paramsJsonSchema,
-      recipientsJsonSchema,
       contentJsonSchema,
       sendParamsJsonSchema,
+      recipientTypeRegistry,
     );
   }
 

--- a/lib/providers/SmtpProvider.ts
+++ b/lib/providers/SmtpProvider.ts
@@ -17,6 +17,7 @@ export interface SMTPAccount extends BaseAccount<
 
 export class SmtpProvider extends BaseProvider<SMTPAccount> {
   override supportAttachment = true;
+  override messageType: "short" | "long" = "long";
 
   constructor() {
     const paramsJsonSchema: JSONSchema7 = {

--- a/lib/providers/SmtpProvider.ts
+++ b/lib/providers/SmtpProvider.ts
@@ -65,7 +65,7 @@ export class SmtpProvider extends BaseProvider<SMTPAccount> {
         message: {
           type: "string",
           title: "Message",
-          format: "long-text",
+          $comment: "long-text",
         },
       },
       required: ["subject", "message"],
@@ -75,6 +75,14 @@ export class SmtpProvider extends BaseProvider<SMTPAccount> {
       type: "object",
       properties: {
         from: { type: "string" },
+        cc: {
+          type: "string",
+          title: "Cc",
+        },
+        bcc: {
+          type: "string",
+          title: "Bcc",
+        },
         attachments: {
           type: "array",
           items: {
@@ -115,8 +123,8 @@ export class SmtpProvider extends BaseProvider<SMTPAccount> {
    * Sends an email using one of the registered SMTP accounts.
    *
    * @param accountName - Name of the registered account to use
-   * @param recipients - Array of recipient objects with `to` (required), `cc` and `bcc` (optional)
-   * @param content - Email content: `subject` and `message` (HTML)
+   * @param recipients - Array of recipient objects with `to` (required)
+   * @param content - Email content: `subject` and `message` (HTML), plus optional `cc` and `bcc`
    * @param params.from - Sender override; falls back to the account's `default_sender`
    * @param params.attachments - Optional file attachments
    */
@@ -124,7 +132,17 @@ export class SmtpProvider extends BaseProvider<SMTPAccount> {
     accountName: string,
     recipients: any[],
     content: any,
-    { attachments, from }: { attachments?: Attachment[]; from?: string } = {},
+    {
+      attachments,
+      from,
+      cc,
+      bcc,
+    }: {
+      attachments?: Attachment[];
+      from?: string;
+      cc?: string;
+      bcc?: string;
+    } = {},
   ) {
     const account = this.getAccount(accountName);
     const fromEmail = from || account.options.defaultSender;
@@ -135,6 +153,8 @@ export class SmtpProvider extends BaseProvider<SMTPAccount> {
       subject: content.subject,
       html: content.message,
       to: recipients.map((r) => r.to).join(", "),
+      cc: cc,
+      bcc: bcc,
     };
 
     try {

--- a/lib/providers/SmtpProvider.ts
+++ b/lib/providers/SmtpProvider.ts
@@ -4,8 +4,8 @@ import { Transporter, createTransport } from "nodemailer";
 import Mail from "nodemailer/lib/mailer";
 import SMTPTransport from "nodemailer/lib/smtp-transport";
 
-import { Attachment } from "../types";
-import { BaseAccount, BaseProvider, ProviderType } from "./BaseProvider";
+import { Attachment, ProviderCapabilities } from "../types";
+import { BaseAccount, BaseProvider } from "./BaseProvider";
 import { RecipientTypeRegistry } from "../recipients";
 
 export interface SMTPAccount extends BaseAccount<
@@ -17,8 +17,12 @@ export interface SMTPAccount extends BaseAccount<
 }
 
 export class SmtpProvider extends BaseProvider<SMTPAccount> {
-  override supportAttachment = true;
-  override messageType: "short" | "long" = "long";
+  override capabilities: ProviderCapabilities = {
+    longMessage: true,
+    shortMessage: true,
+    fileAttachment: true,
+    json: false,
+  };
 
   constructor(recipientTypeRegistry: RecipientTypeRegistry) {
     const paramsJsonSchema: JSONSchema7 = {
@@ -110,7 +114,6 @@ export class SmtpProvider extends BaseProvider<SMTPAccount> {
 
     super(
       "smtp",
-      ProviderType.EMAIL,
       ["email"],
       paramsJsonSchema,
       contentJsonSchema,

--- a/lib/providers/SmtpProvider.ts
+++ b/lib/providers/SmtpProvider.ts
@@ -6,6 +6,7 @@ import SMTPTransport from "nodemailer/lib/smtp-transport";
 
 import { Attachment } from "../types";
 import { BaseAccount, BaseProvider, ProviderType } from "./BaseProvider";
+import { RecipientTypeRegistry } from "../recipients";
 
 export interface SMTPAccount extends BaseAccount<
   Transporter<SMTPTransport.SentMessageInfo>
@@ -19,7 +20,7 @@ export class SmtpProvider extends BaseProvider<SMTPAccount> {
   override supportAttachment = true;
   override messageType: "short" | "long" = "long";
 
-  constructor() {
+  constructor(recipientTypeRegistry: RecipientTypeRegistry) {
     const paramsJsonSchema: JSONSchema7 = {
       type: "object",
       properties: {
@@ -54,26 +55,6 @@ export class SmtpProvider extends BaseProvider<SMTPAccount> {
       required: ["host_name", "port", "user", "password", "default_sender"],
     };
 
-    const recipientsJsonSchema: JSONSchema7 = {
-      type: "object",
-      properties: {
-        to: {
-          type: "string",
-          title: "Email",
-          pattern: String.raw`^[\w._%+-]+@[\w.-]+\.[a-zA-Z]{2,}$`,
-        },
-        cc: {
-          type: "string",
-          title: "Cc",
-        },
-        bcc: {
-          type: "string",
-          title: "Bcc",
-        },
-      },
-      required: ["to"],
-    };
-
     const contentJsonSchema: JSONSchema7 = {
       type: "object",
       properties: {
@@ -84,6 +65,7 @@ export class SmtpProvider extends BaseProvider<SMTPAccount> {
         message: {
           type: "string",
           title: "Message",
+          format: "long-text",
         },
       },
       required: ["subject", "message"],
@@ -121,10 +103,11 @@ export class SmtpProvider extends BaseProvider<SMTPAccount> {
     super(
       "smtp",
       ProviderType.EMAIL,
+      ["email"],
       paramsJsonSchema,
-      recipientsJsonSchema,
       contentJsonSchema,
       sendParamsJsonSchema,
+      recipientTypeRegistry,
     );
   }
 

--- a/lib/providers/SmtpProvider.ts
+++ b/lib/providers/SmtpProvider.ts
@@ -202,7 +202,6 @@ export class SmtpProvider extends BaseProvider<SMTPAccount> {
       port,
       secure: port === 465,
     });
-
     return {
       provider: transporter,
       name,
@@ -223,11 +222,10 @@ export class SmtpProvider extends BaseProvider<SMTPAccount> {
     } else {
       try {
         await account.provider.verify();
+        return account.provider.sendMail(email);
       } catch (error) {
         throw new ExternalServiceError(error);
       }
-
-      return account.provider.sendMail(email);
     }
   }
 

--- a/lib/providers/SmtpProvider.ts
+++ b/lib/providers/SmtpProvider.ts
@@ -148,7 +148,10 @@ export class SmtpProvider extends BaseProvider<SMTPAccount> {
     const fromEmail = from || account.options.defaultSender;
 
     const email: Mail.Options = {
-      attachments,
+      attachments: attachments?.map((attachment) => ({
+        ...attachment,
+        encoding: "base64",
+      })),
       from: fromEmail,
       subject: content.subject,
       html: content.message,

--- a/lib/providers/TwilioProvider.ts
+++ b/lib/providers/TwilioProvider.ts
@@ -2,8 +2,9 @@ import { ExternalServiceError } from "kuzzle";
 import { JSONSchema7 } from "json-schema";
 import { Twilio } from "twilio";
 
-import { BaseAccount, BaseProvider, ProviderType } from "./BaseProvider";
+import { BaseAccount, BaseProvider } from "./BaseProvider";
 import { RecipientTypeRegistry } from "../recipients";
+import { ProviderCapabilities } from "../types";
 
 export interface TwilioAccount extends BaseAccount<Twilio> {
   options: {
@@ -12,6 +13,12 @@ export interface TwilioAccount extends BaseAccount<Twilio> {
 }
 
 export class TwilioProvider extends BaseProvider<TwilioAccount> {
+  override capabilities: ProviderCapabilities = {
+    longMessage: false,
+    shortMessage: true,
+    fileAttachment: false,
+    json: false,
+  };
   constructor(recipientTypeRegistry: RecipientTypeRegistry) {
     const paramsJsonSchema: JSONSchema7 = {
       type: "object",
@@ -57,7 +64,6 @@ export class TwilioProvider extends BaseProvider<TwilioAccount> {
 
     super(
       "twilio",
-      ProviderType.SMS,
       ["phoneNumber"],
       paramsJsonSchema,
       contentJsonSchema,

--- a/lib/providers/TwilioProvider.ts
+++ b/lib/providers/TwilioProvider.ts
@@ -42,6 +42,7 @@ export class TwilioProvider extends BaseProvider<TwilioAccount> {
           type: "string",
           title: "Phone Number",
           minLength: 1,
+          pattern: String.raw`^\+[1-9]\d{1,14}$`,
         },
       },
       required: ["to"],

--- a/lib/providers/TwilioProvider.ts
+++ b/lib/providers/TwilioProvider.ts
@@ -3,6 +3,7 @@ import { JSONSchema7 } from "json-schema";
 import { Twilio } from "twilio";
 
 import { BaseAccount, BaseProvider, ProviderType } from "./BaseProvider";
+import { RecipientTypeRegistry } from "../recipients";
 
 export interface TwilioAccount extends BaseAccount<Twilio> {
   options: {
@@ -11,7 +12,7 @@ export interface TwilioAccount extends BaseAccount<Twilio> {
 }
 
 export class TwilioProvider extends BaseProvider<TwilioAccount> {
-  constructor() {
+  constructor(recipientTypeRegistry: RecipientTypeRegistry) {
     const paramsJsonSchema: JSONSchema7 = {
       type: "object",
       properties: {
@@ -33,19 +34,6 @@ export class TwilioProvider extends BaseProvider<TwilioAccount> {
         },
       },
       required: ["account_sid", "auth_token", "default_sender"],
-    };
-
-    const recipientsJsonSchema: JSONSchema7 = {
-      type: "object",
-      properties: {
-        to: {
-          type: "string",
-          title: "Phone Number",
-          minLength: 1,
-          pattern: String.raw`^\+[1-9]\d{1,14}$`,
-        },
-      },
-      required: ["to"],
     };
 
     const contentJsonSchema: JSONSchema7 = {
@@ -70,10 +58,11 @@ export class TwilioProvider extends BaseProvider<TwilioAccount> {
     super(
       "twilio",
       ProviderType.SMS,
+      ["phoneNumber"],
       paramsJsonSchema,
-      recipientsJsonSchema,
       contentJsonSchema,
       sendParamsJsonSchema,
+      recipientTypeRegistry,
     );
   }
 

--- a/lib/providers/index.ts
+++ b/lib/providers/index.ts
@@ -1,4 +1,5 @@
 export * from "./BaseProvider";
+export * from "./ProviderManager";
 export * from "./SendgridProvider";
 export * from "./SMSEnvoiProvider";
 export * from "./SmtpProvider";

--- a/lib/recipients/RecipientType.ts
+++ b/lib/recipients/RecipientType.ts
@@ -1,0 +1,58 @@
+import { JSONSchema7 } from "json-schema";
+import { BadRequestError, NotFoundError } from "kuzzle";
+import isEqual from "lodash/isEqual";
+export interface RecipientTypeLocale {
+  label: string;
+  description?: string;
+}
+
+export interface RecipientTypeDefinition {
+  /** Unique registry key, e.g. 'email', 'phoneNumber', 'pushToken', 'webhookUrl'. */
+  name: string;
+  /** Coarse category — multiple `name`s may share the same `type` (e.g. future 'workEmail' and 'personalEmail' could both be type 'email'). */
+  type: string;
+  /** Fallback/default human description. */
+  description: string;
+  /** JSON Schema describing the shape of ONE recipient entry for this type. */
+  jsonSchema: JSONSchema7;
+}
+
+export class RecipientTypeRegistry {
+  private definitions = new Map<string, RecipientTypeDefinition>();
+
+  register(definition: RecipientTypeDefinition): void {
+    const existing = this.definitions.get(definition.name);
+
+    if (existing) {
+      const isIdentical = isEqual(existing, definition);
+
+      if (isIdentical) {
+        return;
+      }
+
+      throw new BadRequestError(
+        `Recipient type "${definition.name}" is already registered with a different type/jsonSchema.`,
+      );
+    }
+
+    this.definitions.set(definition.name, definition);
+  }
+
+  has(name: string): boolean {
+    return this.definitions.has(name);
+  }
+
+  get(name: string): RecipientTypeDefinition {
+    const definition = this.definitions.get(name);
+
+    if (!definition) {
+      throw new NotFoundError(`Recipient type "${name}" is not registered.`);
+    }
+
+    return definition;
+  }
+
+  list(): RecipientTypeDefinition[] {
+    return Array.from(this.definitions.values());
+  }
+}

--- a/lib/recipients/RecipientType.ts
+++ b/lib/recipients/RecipientType.ts
@@ -9,8 +9,6 @@ export interface RecipientTypeLocale {
 export interface RecipientTypeDefinition {
   /** Unique registry key, e.g. 'email', 'phoneNumber', 'pushToken', 'webhookUrl'. */
   name: string;
-  /** Coarse category — multiple `name`s may share the same `type` (e.g. future 'workEmail' and 'personalEmail' could both be type 'email'). */
-  type: string;
   /** Fallback/default human description. */
   description: string;
   /** JSON Schema describing the shape of ONE recipient entry for this type. */
@@ -31,7 +29,7 @@ export class RecipientTypeRegistry {
       }
 
       throw new BadRequestError(
-        `Recipient type "${definition.name}" is already registered with a different type/jsonSchema.`,
+        `Recipient type "${definition.name}" is already registered with a different jsonSchema.`,
       );
     }
 

--- a/lib/recipients/emailRecipient.ts
+++ b/lib/recipients/emailRecipient.ts
@@ -12,14 +12,6 @@ export const emailRecipient: RecipientTypeDefinition = {
         title: "Email",
         pattern: String.raw`^[\w._%+-]+@[\w.-]+\.[a-zA-Z]{2,}$`,
       },
-      cc: {
-        type: "string",
-        title: "Cc",
-      },
-      bcc: {
-        type: "string",
-        title: "Bcc",
-      },
     },
     required: ["to"],
   },

--- a/lib/recipients/emailRecipient.ts
+++ b/lib/recipients/emailRecipient.ts
@@ -2,7 +2,6 @@ import { RecipientTypeDefinition } from "./RecipientType";
 
 export const emailRecipient: RecipientTypeDefinition = {
   name: "email",
-  type: "email",
   description: "An email address",
   jsonSchema: {
     type: "object",

--- a/lib/recipients/emailRecipient.ts
+++ b/lib/recipients/emailRecipient.ts
@@ -1,0 +1,26 @@
+import { RecipientTypeDefinition } from "./RecipientType";
+
+export const emailRecipient: RecipientTypeDefinition = {
+  name: "email",
+  type: "email",
+  description: "An email address",
+  jsonSchema: {
+    type: "object",
+    properties: {
+      to: {
+        type: "string",
+        title: "Email",
+        pattern: String.raw`^[\w._%+-]+@[\w.-]+\.[a-zA-Z]{2,}$`,
+      },
+      cc: {
+        type: "string",
+        title: "Cc",
+      },
+      bcc: {
+        type: "string",
+        title: "Bcc",
+      },
+    },
+    required: ["to"],
+  },
+};

--- a/lib/recipients/index.ts
+++ b/lib/recipients/index.ts
@@ -1,0 +1,3 @@
+export * from "./RecipientType";
+export * from "./emailRecipient";
+export * from "./phoneRecipient";

--- a/lib/recipients/phoneRecipient.ts
+++ b/lib/recipients/phoneRecipient.ts
@@ -2,7 +2,6 @@ import { RecipientTypeDefinition } from "./RecipientType";
 
 export const phoneRecipient: RecipientTypeDefinition = {
   name: "phoneNumber",
-  type: "phone",
   description: "A phone number, in E.164 format",
 
   jsonSchema: {

--- a/lib/recipients/phoneRecipient.ts
+++ b/lib/recipients/phoneRecipient.ts
@@ -1,0 +1,20 @@
+import { RecipientTypeDefinition } from "./RecipientType";
+
+export const phoneRecipient: RecipientTypeDefinition = {
+  name: "phoneNumber",
+  type: "phone",
+  description: "A phone number, in E.164 format",
+
+  jsonSchema: {
+    type: "object",
+    properties: {
+      to: {
+        type: "string",
+        title: "Phone Number",
+        minLength: 1,
+        pattern: String.raw`^\+[1-9]\d{1,14}$`,
+      },
+    },
+    required: ["to"],
+  },
+};

--- a/lib/types/MessageTypes.ts
+++ b/lib/types/MessageTypes.ts
@@ -1,1 +1,0 @@
-export type MessageType = "short" | "long";

--- a/lib/types/MessageTypes.ts
+++ b/lib/types/MessageTypes.ts
@@ -1,0 +1,1 @@
+export type MessageType = "short" | "long";

--- a/lib/types/ProviderCapabilities.ts
+++ b/lib/types/ProviderCapabilities.ts
@@ -1,0 +1,6 @@
+export interface ProviderCapabilities {
+  fileAttachment: boolean;
+  longMessage: boolean;
+  shortMessage: boolean;
+  json: boolean;
+}

--- a/lib/types/SerializedProvider.ts
+++ b/lib/types/SerializedProvider.ts
@@ -1,13 +1,9 @@
 import { JSONSchema7 } from "json-schema";
-
-import { ProviderType } from "../providers/BaseProvider";
-import { MessageType } from "./MessageTypes";
+import { ProviderCapabilities } from "./ProviderCapabilities";
 
 export interface SerializedProvider {
   name: string;
-  type: ProviderType;
-  supportAttachment: boolean;
-  messageType: MessageType;
+  capabilities: ProviderCapabilities;
   acceptedRecipientTypes: string[];
   paramsJsonSchema: JSONSchema7;
   contentJsonSchema: JSONSchema7;

--- a/lib/types/SerializedProvider.ts
+++ b/lib/types/SerializedProvider.ts
@@ -1,0 +1,15 @@
+import { JSONSchema7 } from "json-schema";
+
+import { ProviderType } from "../providers/BaseProvider";
+import { MessageType } from "./MessageTypes";
+
+export interface SerializedProvider {
+  name: string;
+  type: ProviderType;
+  supportAttachment: boolean;
+  messageType: MessageType;
+  acceptedRecipientTypes: string[];
+  paramsJsonSchema: JSONSchema7;
+  contentJsonSchema: JSONSchema7;
+  sendParamsJsonSchema: JSONSchema7;
+}

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -1,3 +1,3 @@
 export * from "./Attachment";
-export * from "./MessageTypes";
 export * from "./SerializedProvider";
+export * from "./ProviderCapabilities";

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -1,2 +1,3 @@
 export * from "./Attachment";
 export * from "./MessageTypes";
+export * from "./SerializedProvider";

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -1,1 +1,2 @@
 export * from "./Attachment";
+export * from "./MessageTypes";

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@types/ajv": "^0.0.5",
         "@types/jest": "30.0.0",
         "@types/json-schema": "^7.0.15",
+        "@types/lodash": "^4.17.24",
         "@types/node": "22.15.21",
         "@types/nodemailer": "6.4.17",
         "cz-conventional-changelog": "3.3.0",
@@ -109,7 +110,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -786,7 +786,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -799,7 +798,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1292,6 +1290,7 @@
       "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -1316,6 +1315,7 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1333,6 +1333,7 @@
       "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1343,7 +1344,8 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.5",
@@ -1351,6 +1353,7 @@
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1364,6 +1367,7 @@
       "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
@@ -1392,6 +1396,7 @@
       "deprecated": "Use @eslint/config-array instead",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^2.0.3",
         "debug": "^4.3.1",
@@ -1407,6 +1412,7 @@
       "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1418,6 +1424,7 @@
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1431,6 +1438,7 @@
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=12.22"
       },
@@ -1445,7 +1453,8 @@
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@inquirer/ansi": {
       "version": "2.0.7",
@@ -4009,7 +4018,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -4157,7 +4165,6 @@
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -5752,6 +5759,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/lodash": {
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mdast": {
       "version": "3.0.15",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.15.tgz",
@@ -5768,7 +5782,6 @@
       "integrity": "sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -5837,7 +5850,6 @@
       "integrity": "sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
         "@typescript-eslint/scope-manager": "7.18.0",
@@ -5872,7 +5884,6 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -6516,7 +6527,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6530,6 +6540,7 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -7289,7 +7300,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -8307,7 +8317,6 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -8499,7 +8508,8 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
@@ -8626,6 +8636,7 @@
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "esutils": "^2.0.2"
       },
@@ -9338,6 +9349,7 @@
       "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -9368,6 +9380,7 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -9385,6 +9398,7 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -9401,6 +9415,7 @@
       "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -9412,6 +9427,7 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -9429,6 +9445,7 @@
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -9441,7 +9458,8 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/eslint/node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -9449,6 +9467,7 @@
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9462,6 +9481,7 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -9471,7 +9491,8 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "3.1.5",
@@ -9479,6 +9500,7 @@
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -9492,6 +9514,7 @@
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -9521,6 +9544,7 @@
       "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "acorn": "^8.9.0",
         "acorn-jsx": "^5.3.2",
@@ -9553,6 +9577,7 @@
       "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -9566,6 +9591,7 @@
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -9579,6 +9605,7 @@
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -9599,6 +9626,7 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9817,7 +9845,8 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
@@ -9956,6 +9985,7 @@
       "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "flat-cache": "^3.0.4"
       },
@@ -10025,6 +10055,7 @@
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -10088,6 +10119,7 @@
       "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "flatted": "^3.2.9",
         "keyv": "^4.5.3",
@@ -10109,7 +10141,8 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
@@ -10511,6 +10544,7 @@
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -10617,6 +10651,7 @@
       "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -11092,6 +11127,7 @@
       "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
@@ -11423,6 +11459,7 @@
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -11647,7 +11684,6 @@
       "integrity": "sha512-/3G2iFwsUY95vkflmlDn/IdLyLWqpQXcftptooaPH4qkyU52V7qVYf1BjmdSPlp1+0fs6BmNtrGaSFwOfV07ew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.0.0",
         "@jest/types": "30.0.0",
@@ -14929,7 +14965,8 @@
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
@@ -14976,7 +15013,8 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
@@ -15096,6 +15134,7 @@
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -15499,6 +15538,7 @@
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -15560,6 +15600,7 @@
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -15666,7 +15707,8 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
@@ -15946,7 +15988,6 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -18791,7 +18832,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18972,6 +19012,7 @@
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -19198,6 +19239,7 @@
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -19578,7 +19620,6 @@
       "integrity": "sha512-noIBaNfEGPglMcZDP2aE3/e4bL1AqS05vmbftNA6ml7f9yaEfv4CEe1PRGr0CxwjYG3/rOAPXgzFDbfPH1GKcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@elastic/elasticsearch": "^8.13.1",
         "minimist": "^1.2.8",
@@ -19714,7 +19755,6 @@
       "integrity": "sha512-2+Y/GEq7Blmv+BZJ1u/4Yx0fAUkbvoLe8M/vpeFAr+ruR6dTyMVSTL/oDS3C2xIpP0k0c0AOnfDHBYHFL1L2AA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",
         "pino-abstract-transport": "^2.0.0",
@@ -19922,6 +19962,7 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -19932,7 +19973,6 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -20130,6 +20170,7 @@
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -20726,6 +20767,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -21026,7 +21068,6 @@
       "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -22432,7 +22473,8 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/thenify": {
       "version": "3.3.1",
@@ -22584,7 +22626,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -22712,7 +22753,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -22764,7 +22804,6 @@
       "integrity": "sha512-gK5GVzDkJK1SI1zwHf32Mqxf2tSJkNx+eYcNly5+nHvWqXUJYUkWBQtKauoESz3ymezAI++ZwT855x5p5eop+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -22820,6 +22859,7 @@
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -22856,7 +22896,6 @@
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -23162,6 +23201,7 @@
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -23902,7 +23942,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/ajv": "^0.0.5",
     "@types/jest": "30.0.0",
     "@types/json-schema": "^7.0.15",
+    "@types/lodash": "^4.17.24",
     "@types/node": "22.15.21",
     "@types/nodemailer": "6.4.17",
     "cz-conventional-changelog": "3.3.0",

--- a/tests/mocks/TestProvider.ts
+++ b/tests/mocks/TestProvider.ts
@@ -9,22 +9,27 @@ export interface TestAccount extends BaseAccount<null> {
 }
 
 export class TestProvider extends BaseProvider<TestAccount> {
-  constructor() {
+  constructor(
+    recipientTypeRegistry: RecipientTypeRegistry = new RecipientTypeRegistry(),
+    acceptedRecipientTypes: string[] = ["testRecipient"],
+  ) {
     const paramsJsonSchema: JSONSchema7 = { type: "object" };
     const contentJsonSchema: JSONSchema7 = { type: "object" };
     const sendParamsJsonSchema: JSONSchema7 = { type: "object" };
-    const recipientTypeRegistry = new RecipientTypeRegistry();
-    recipientTypeRegistry.register({
-      name: "testRecipient",
-      type: "test",
-      description: "Test recipient type",
-      jsonSchema: { type: "object" },
-    });
+
+    if (!recipientTypeRegistry.has("testRecipient")) {
+      recipientTypeRegistry.register({
+        name: "testRecipient",
+        type: "test",
+        description: "Test recipient type",
+        jsonSchema: { type: "object" },
+      });
+    }
 
     super(
       "testProvider",
       ProviderType.SMS,
-      ["testRecipient"],
+      acceptedRecipientTypes,
       paramsJsonSchema,
       contentJsonSchema,
       sendParamsJsonSchema,

--- a/tests/mocks/TestProvider.ts
+++ b/tests/mocks/TestProvider.ts
@@ -1,7 +1,8 @@
 import { JSONSchema7 } from "json-schema";
 import { PluginContext } from "kuzzle";
-import { BaseAccount, BaseProvider, ProviderType } from "lib/providers";
+import { BaseAccount, BaseProvider } from "lib/providers";
 import { RecipientTypeRegistry } from "lib/recipients";
+import { ProviderCapabilities } from "lib/types";
 import { vi } from "vitest";
 
 export interface TestAccount extends BaseAccount<null> {
@@ -9,6 +10,12 @@ export interface TestAccount extends BaseAccount<null> {
 }
 
 export class TestProvider extends BaseProvider<TestAccount> {
+  override capabilities: ProviderCapabilities = {
+    fileAttachment: false,
+    longMessage: false,
+    shortMessage: true,
+    json: false,
+  };
   constructor(
     recipientTypeRegistry: RecipientTypeRegistry = new RecipientTypeRegistry(),
     acceptedRecipientTypes: string[] = ["testRecipient"],
@@ -20,7 +27,6 @@ export class TestProvider extends BaseProvider<TestAccount> {
     if (!recipientTypeRegistry.has("testRecipient")) {
       recipientTypeRegistry.register({
         name: "testRecipient",
-        type: "test",
         description: "Test recipient type",
         jsonSchema: { type: "object" },
       });
@@ -28,7 +34,6 @@ export class TestProvider extends BaseProvider<TestAccount> {
 
     super(
       "testProvider",
-      ProviderType.SMS,
       acceptedRecipientTypes,
       paramsJsonSchema,
       contentJsonSchema,

--- a/tests/mocks/TestProvider.ts
+++ b/tests/mocks/TestProvider.ts
@@ -1,6 +1,7 @@
 import { JSONSchema7 } from "json-schema";
 import { PluginContext } from "kuzzle";
 import { BaseAccount, BaseProvider, ProviderType } from "lib/providers";
+import { RecipientTypeRegistry } from "lib/recipients";
 import { vi } from "vitest";
 
 export interface TestAccount extends BaseAccount<null> {
@@ -10,15 +11,24 @@ export interface TestAccount extends BaseAccount<null> {
 export class TestProvider extends BaseProvider<TestAccount> {
   constructor() {
     const paramsJsonSchema: JSONSchema7 = { type: "object" };
-    const recipientsJsonSchema: JSONSchema7 = { type: "object" };
     const contentJsonSchema: JSONSchema7 = { type: "object" };
+    const sendParamsJsonSchema: JSONSchema7 = { type: "object" };
+    const recipientTypeRegistry = new RecipientTypeRegistry();
+    recipientTypeRegistry.register({
+      name: "testRecipient",
+      type: "test",
+      description: "Test recipient type",
+      jsonSchema: { type: "object" },
+    });
 
     super(
       "testProvider",
       ProviderType.SMS,
+      ["testRecipient"],
       paramsJsonSchema,
-      recipientsJsonSchema,
       contentJsonSchema,
+      sendParamsJsonSchema,
+      recipientTypeRegistry,
     );
   }
 

--- a/tests/scenarios/testProvider.test.ts
+++ b/tests/scenarios/testProvider.test.ts
@@ -107,7 +107,7 @@ describe("TestProvider", () => {
 
     const validateParamsSpy = vi.spyOn(testProvider, "validateParams");
 
-    testProvider.validateParams({ type: "object" });
+    testProvider.validateAccountParams({ type: "object" });
 
     expect(validateParamsSpy).toHaveBeenCalledWith({ type: "object" });
 

--- a/tests/scenarios/testProvider.test.ts
+++ b/tests/scenarios/testProvider.test.ts
@@ -105,7 +105,7 @@ describe("TestProvider", () => {
   it("Validate params", async () => {
     const testProvider = new TestProvider();
 
-    const validateParamsSpy = vi.spyOn(testProvider, "validateParams");
+    const validateParamsSpy = vi.spyOn(testProvider, "validateAccountParams");
 
     testProvider.validateAccountParams({ type: "object" });
 
@@ -153,9 +153,9 @@ describe("TestProvider", () => {
   it("Get params json", async () => {
     const testProvider = new TestProvider();
 
-    const getNameSpy = vi.spyOn(testProvider, "getParamsJsonSchema");
+    const getNameSpy = vi.spyOn(testProvider, "getAccountParamsJsonSchema");
 
-    testProvider.getParamsJsonSchema();
+    testProvider.getAccountParamsJsonSchema();
 
     expect(getNameSpy).toHaveBeenCalledWith();
 
@@ -204,7 +204,6 @@ describe("TestProvider", () => {
   describe("Custom recipient type registration", () => {
     const webhookRecipient: RecipientTypeDefinition = {
       name: "webhookUrl",
-      type: "webhook",
       description: "An HTTP endpoint to POST the message to",
       jsonSchema: {
         type: "object",
@@ -260,7 +259,7 @@ describe("TestProvider", () => {
           jsonSchema: { type: "object" },
         }),
       ).toThrowError(
-        'Recipient type "webhookUrl" is already registered with a different type/jsonSchema.',
+        'Recipient type "webhookUrl" is already registered with a different jsonSchema.',
       );
     });
   });

--- a/tests/scenarios/testProvider.test.ts
+++ b/tests/scenarios/testProvider.test.ts
@@ -1,5 +1,6 @@
 import { defineReflectProperties } from "tests/helpers";
 import { context, TestProvider } from "tests/mocks";
+import { RecipientTypeDefinition, RecipientTypeRegistry } from "lib/recipients";
 import { describe, it, expect, vi } from "vitest";
 
 beforeAll(() => {
@@ -198,5 +199,69 @@ describe("TestProvider", () => {
     expect(nodeRemoveAccountSpy).toHaveBeenCalledWith("myaccount");
 
     initSpy.mockRestore();
+  });
+
+  describe("Custom recipient type registration", () => {
+    const webhookRecipient: RecipientTypeDefinition = {
+      name: "webhookUrl",
+      type: "webhook",
+      description: "An HTTP endpoint to POST the message to",
+      jsonSchema: {
+        type: "object",
+        properties: { to: { type: "string" } },
+        required: ["to"],
+      },
+    };
+
+    it("accepts a provider referencing a custom registered recipient type", () => {
+      const registry = new RecipientTypeRegistry();
+      registry.register(webhookRecipient);
+
+      const testProvider = new TestProvider(registry, ["webhookUrl"]);
+
+      expect(testProvider.getAcceptedRecipientTypes()).toEqual(["webhookUrl"]);
+      expect(() =>
+        testProvider.validateRecipients({ to: "https://example.com/hook" }),
+      ).not.toThrow();
+    });
+
+    it("rejects a recipient that does not match the custom type's schema", () => {
+      const registry = new RecipientTypeRegistry();
+      registry.register(webhookRecipient);
+
+      const testProvider = new TestProvider(registry, ["webhookUrl"]);
+
+      expect(() => testProvider.validateRecipients({})).toThrowError();
+    });
+
+    it("throws when a provider references an unregistered recipient type", () => {
+      const registry = new RecipientTypeRegistry();
+
+      expect(() => new TestProvider(registry, ["unknownType"])).toThrowError(
+        'Recipient type "unknownType" is not registered.',
+      );
+    });
+
+    it("registering the same recipient type twice with an identical definition is a no-op", () => {
+      const registry = new RecipientTypeRegistry();
+      registry.register(webhookRecipient);
+
+      expect(() => registry.register({ ...webhookRecipient })).not.toThrow();
+      expect(registry.list()).toHaveLength(1);
+    });
+
+    it("registering the same recipient type twice with a conflicting definition throws", () => {
+      const registry = new RecipientTypeRegistry();
+      registry.register(webhookRecipient);
+
+      expect(() =>
+        registry.register({
+          ...webhookRecipient,
+          jsonSchema: { type: "object" },
+        }),
+      ).toThrowError(
+        'Recipient type "webhookUrl" is already registered with a different type/jsonSchema.',
+      );
+    });
   });
 });


### PR DESCRIPTION
## What does this PR do ?
Refactor the `supportAttachment`, `messageType`, `providerType` and recipient validation

Now a provider must declare its capabiliites 
```ts
export class SmtpProvider extends BaseProvider<SMTPAccount> {
  override capabilities: ProviderCapabilities = {
    longMessage: true,
    shortMessage: true,
    fileAttachment: true,
    json: false,
  };
  // ....
  }
```

Add a `recipientType` and `RecipientTypeRegistry`
```ts
export interface RecipientTypeDefinition {
  /** Unique registry key, e.g. 'email', 'phoneNumber', 'pushToken', 'webhookUrl'. */
  name: string;
  /** Fallback/default human description. */
  description: string;
  /** JSON Schema describing the shape of ONE recipient entry for this type. */
  jsonSchema: JSONSchema7;
}

```



Recipient types holds the validation for recipients and can be shared accross providers, Hermes plugin provides `email` and `phoneNumber`
But recipientTypes can be added

```typescript
import {
  RecipientTypeDefinition,
  HermesMessengerPlugin,
} from "kuzzle-plugin-hermes-messenger";

const webhookUrlRecipient: RecipientTypeDefinition = {
  name: "webhookUrl", // unique registry key, referenced by acceptedRecipientTypes
  description: "An HTTP endpoint to POST the message to",
  jsonSchema: {
    type: "object",
    properties: {
      to: { type: "string", format: "uri", title: "Webhook URL" },
    },
    required: ["to"],
  },
};

const plugin = new HermesMessengerPlugin();

// Must be registered before any provider that lists 'webhookUrl' in its
// acceptedRecipientTypes.
plugin.registerRecipientType(webhookUrlRecipient);
```

Add filter object in listProviders to filter according to provider capabiliites
